### PR TITLE
server: add an admin route for displaying the config

### DIFF
--- a/internal/admin_config.go
+++ b/internal/admin_config.go
@@ -1,0 +1,35 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func (env *Environment) registerConfigRoute() {
+	env.AdminServer.AddHandler("/config", env.configRouteHandler())
+}
+
+func (env *Environment) configRouteHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(env.Config)
+	}
+}

--- a/internal/server.go
+++ b/internal/server.go
@@ -38,7 +38,8 @@ import (
 func (env *Environment) RunServers(terminationListener chan error) func() {
 	env.AdminServer = bootAdminServer(terminationListener, env.Logger, env.Config.Admin)
 
-	// register an admin route
+	// register the admin routes
+	env.registerConfigRoute()
 	env.FileReceiver.RegisterAdminRoutes(env.AdminServer)
 
 	_, shutdownPublicServer := bootHTTPServer("public", env.PublicRouter, terminationListener, env.Logger, env.Config.Inbound.HTTP)


### PR DESCRIPTION
This is helpful to show the resolved config from achgateway's perspective. 