### PR TITLE
audittrail: save agent hostname in blob path

### DIFF
--- a/internal/audittrail/storage.go
+++ b/internal/audittrail/storage.go
@@ -33,7 +33,7 @@ var (
 // File retention after upload is not part of this storage.
 type Storage interface {
 	// SaveFile will encrypt and copy the ACH file to the configured file storage.
-	SaveFile(filename string, file *ach.File) error
+	SaveFile(hostname, filename string, file *ach.File) error
 
 	GetFile(filepath string) (io.ReadCloser, error)
 

--- a/internal/audittrail/storage_blob.go
+++ b/internal/audittrail/storage_blob.go
@@ -67,7 +67,7 @@ func (bs *blobStorage) Close() error {
 	return bs.bucket.Close()
 }
 
-func (bs *blobStorage) SaveFile(filename string, file *ach.File) error {
+func (bs *blobStorage) SaveFile(hostname, filename string, file *ach.File) error {
 	result := &transform.Result{File: file}
 
 	var buf bytes.Buffer
@@ -83,7 +83,7 @@ func (bs *blobStorage) SaveFile(filename string, file *ach.File) error {
 	}
 
 	// write the file in a sub-path of the yyy-mm-dd
-	path := fmt.Sprintf("files/%s/%s", time.Now().Format("2006-01-02"), filename)
+	path := fmt.Sprintf("files/%s/%s/%s", hostname, time.Now().Format("2006-01-02"), filename)
 	w, err := bs.bucket.NewWriter(context.Background(), path, nil)
 	if err != nil {
 		uploadFilesErrors.With("type", "blob").Add(1)

--- a/internal/audittrail/storage_blob_test.go
+++ b/internal/audittrail/storage_blob_test.go
@@ -36,11 +36,11 @@ func TestBlobStorage(t *testing.T) {
 	file, err := ach.ReadFile(ppdPath)
 	require.NoError(t, err)
 
-	if err := store.SaveFile("saved.ach", file); err != nil {
+	if err := store.SaveFile("ftp.dev.com", "saved.ach", file); err != nil {
 		t.Fatal(err)
 	}
 
-	path := fmt.Sprintf("files/%s/saved.ach", time.Now().Format("2006-01-02"))
+	path := fmt.Sprintf("files/ftp.dev.com/%s/saved.ach", time.Now().Format("2006-01-02"))
 	r, err := store.GetFile(path)
 	require.NoError(t, err)
 	defer r.Close()

--- a/internal/audittrail/storage_mock.go
+++ b/internal/audittrail/storage_mock.go
@@ -29,7 +29,7 @@ func (s *MockStorage) Close() error {
 	return s.Err
 }
 
-func (s *MockStorage) SaveFile(filename string, file *ach.File) error {
+func (s *MockStorage) SaveFile(hostname, filename string, file *ach.File) error {
 	if s.Err != nil {
 		uploadFilesErrors.With("type", "mock").Add(1)
 	} else {

--- a/internal/pipeline/aggregate.go
+++ b/internal/pipeline/aggregate.go
@@ -232,7 +232,7 @@ func (xfagg *aggregator) uploadFile(agent upload.Agent, res *transform.Result) e
 	}
 
 	// Record the file in our audit trail
-	if err := xfagg.auditStorage.SaveFile(filename, res.File); err != nil {
+	if err := xfagg.auditStorage.SaveFile(agent.Hostname(), filename, res.File); err != nil {
 		uploadFilesErrors.With().Add(1)
 		return fmt.Errorf("problem saving file in audit record: %v", err)
 	}


### PR DESCRIPTION
This helps to organize uploaded files better with multiple destinations. 