### PR TITLE
upload: offer ShardName and Index for filename templates

### DIFF
--- a/internal/pipeline/mock_xfer_merging.go
+++ b/internal/pipeline/mock_xfer_merging.go
@@ -41,7 +41,7 @@ func (merge *MockXferMerging) HandleCancel(cancel incoming.CancelACHFile) error 
 	return merge.Err
 }
 
-func (merge *MockXferMerging) WithEachMerged(f func(upload.Agent, *ach.File) error) (*processedFiles, error) {
+func (merge *MockXferMerging) WithEachMerged(f func(int, upload.Agent, *ach.File) error) (*processedFiles, error) {
 	if merge.Err != nil {
 		return nil, merge.Err
 	}

--- a/internal/service/model_sharding.go
+++ b/internal/service/model_sharding.go
@@ -30,6 +30,7 @@ var (
 	// The format consists of a few parts: "year month day" timestamp, "hour minute" timestamp, and routing number
 	//
 	// Examples:
+	//  - 20191010-0830-LiveODFI.ach      (.ShardName of "LiveODFI")
 	//  - 20191010-0830-987654320.ach
 	//  - 20191010-0830-987654320.ach.gpg (GPG encrypted)
 	DefaultFilenameTemplate = `{{ date "20060102" }}-{{ date "150405" }}-{{ .RoutingNumber }}.ach{{ if .GPG }}.gpg{{ end }}`

--- a/internal/upload/filename_template.go
+++ b/internal/upload/filename_template.go
@@ -19,6 +19,12 @@ type FilenameData struct {
 
 	// GPG is true if the file has been encrypted with GPG
 	GPG bool
+
+	// Index is the Nth file uploaded for a shard during a cutoff time
+	Index int
+
+	// ShardName is the name of a shard uploading this file
+	ShardName string
 }
 
 var filenameFunctions template.FuncMap = map[string]interface{}{
@@ -27,6 +33,12 @@ var filenameFunctions template.FuncMap = map[string]interface{}{
 	},
 	"env": func(name string) string {
 		return os.Getenv(name)
+	},
+	"lower": func(s string) string {
+		return strings.ToLower(s)
+	},
+	"upper": func(s string) string {
+		return strings.ToUpper(s)
 	},
 }
 

--- a/internal/upload/filename_template_test.go
+++ b/internal/upload/filename_template_test.go
@@ -78,6 +78,14 @@ func TestFilenameTemplate__functions(t *testing.T) {
 			tmpl:     `{{ date "2006-01-02" }}`,
 			expected: time.Now().Format("2006-01-02"),
 		},
+		{
+			tmpl:     `foo-{{ upper .ShardName }}-{{ .Index }}.ach`,
+			expected: "foo-LIVE-1.ach",
+			data: FilenameData{
+				ShardName: "live",
+				Index:     1,
+			},
+		},
 	}
 	for i := range cases {
 		res, err := RenderACHFilename(cases[i].tmpl, cases[i].data)


### PR DESCRIPTION
This allows templates like `foo-{{ upper .ShardName }}-{{ .Index }}.ach` to generate filenames like "foo-LIVE-1.ach".
