### PR TITLE
read message body into Event type

### DIFF
--- a/internal/incoming/web/api_files_test.go
+++ b/internal/incoming/web/api_files_test.go
@@ -20,7 +20,6 @@ package web
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -31,6 +30,7 @@ import (
 	"github.com/moov-io/achgateway/internal/incoming"
 	"github.com/moov-io/achgateway/internal/incoming/stream/streamtest"
 	"github.com/moov-io/achgateway/internal/service"
+	"github.com/moov-io/achgateway/pkg/models"
 	"github.com/moov-io/base/log"
 
 	"github.com/gorilla/mux"
@@ -58,7 +58,7 @@ func TestCreateFileHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	var file incoming.ACHFile
-	require.NoError(t, json.Unmarshal(msg.Body, &file))
+	require.NoError(t, models.ReadEvent(msg.Body, &file))
 
 	require.Equal(t, "f1", file.FileID)
 	require.Equal(t, "s1", file.ShardKey)

--- a/internal/pipeline/file_receiver.go
+++ b/internal/pipeline/file_receiver.go
@@ -19,7 +19,6 @@ package pipeline
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/moov-io/achgateway/internal/incoming"
 	"github.com/moov-io/achgateway/internal/shards"
@@ -128,10 +127,11 @@ func (fr *FileReceiver) handleMessage(ctx context.Context, sub *pubsub.Subscript
 
 			// Parse our incoming ACHFile
 			var file incoming.ACHFile
-			if err := json.Unmarshal(data, &file); err != nil {
+			if err := models.ReadEvent(data, &file); err != nil {
 				fr.logger.Error().LogErrorf("unable to parse incoming.ACHFile: %v", err)
 				return
 			}
+
 			if err := file.Validate(); err != nil {
 				fr.logger.Error().LogErrorf("invalid ACHFile: %v", err)
 				return


### PR DESCRIPTION
# Changes

* Unmarshal received message into `Event` type
* in web API, before we publish a message to the queue, pass it to the `compliance.Protect` as the consumer expects it to be protected.


# Why Are Changes Being Made

ach-orchestrator publishes messages (encrypted, etc.) of the `Event` type.  When achgateway consumes the message from the queue, it should unmarshal it into `Event` type, not into `ACHFile`.
