### PR TITLE
meta: fixup from adding gosec linter

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,9 +40,10 @@ jobs:
 
     - name: Check
       if: runner.os == 'Linux'
+      run: make check
       env:
         COVER_THRESHOLD: 44.5
-      run: make check
+        GOLANGCI_LINTERS: gosec
 
     - name: Upload Code Coverage
       if: runner.os == 'Linux'

--- a/internal/httptest/certs.go
+++ b/internal/httptest/certs.go
@@ -41,7 +41,7 @@ func GrabConnectionCertificates(t *testing.T, addr string) (string, error) {
 			t.Fatal(err)
 		}
 	}
-	if err := ioutil.WriteFile(fd.Name(), buf.Bytes(), 0644); err != nil {
+	if err := ioutil.WriteFile(fd.Name(), buf.Bytes(), 0600); err != nil {
 		t.Fatal(err)
 	}
 	return fd.Name(), nil

--- a/internal/incoming/odfi/cleanup_test.go
+++ b/internal/incoming/odfi/cleanup_test.go
@@ -44,7 +44,7 @@ func TestCleanupErr(t *testing.T) {
 	if err := os.MkdirAll(path, 0777); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(path, "file.ach"), []byte("data"), 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(path, "file.ach"), []byte("data"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -71,7 +71,7 @@ func Test_CleanupEmptyFiles_InboundPath_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(path, "empty_file.ach"), []byte(""), 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(path, "empty_file.ach"), []byte(""), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -96,7 +96,7 @@ func Test_CleanupEmptyFiles_ReconciliationPath_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(path, "empty_file.ach"), []byte(""), 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(path, "empty_file.ach"), []byte(""), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -121,7 +121,7 @@ func Test_CleanupEmptyFiles_ReturnPath_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(path, "empty_file.ach"), []byte(""), 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(path, "empty_file.ach"), []byte(""), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -146,7 +146,7 @@ func Test_CleanupEmptyFiles_PopulatedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(path, "file.ach"), []byte("sameple data"), 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(path, "file.ach"), []byte("sameple data"), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/incoming/odfi/download_test.go
+++ b/internal/incoming/odfi/download_test.go
@@ -41,7 +41,7 @@ func TestDownloader__deleteFiles(t *testing.T) {
 
 	// write a file and expect it to be deleted
 	path := filepath.Join(dl.dir, agent.InboundPath(), "foo.ach")
-	if err := ioutil.WriteFile(path, []byte("testing"), 0644); err != nil {
+	if err := ioutil.WriteFile(path, []byte("testing"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if err := dl.deleteFiles(); err != nil {
@@ -70,7 +70,7 @@ func TestDownloader__deleteEmptyDirs(t *testing.T) {
 
 	// write a file and expect it to be deleted
 	path := filepath.Join(dl.dir, agent.InboundPath(), "foo.ach")
-	if err := ioutil.WriteFile(path, []byte("testing"), 0644); err != nil {
+	if err := ioutil.WriteFile(path, []byte("testing"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if err := dl.deleteEmptyDirs(agent); err != nil {

--- a/internal/incoming/odfi/processor_test.go
+++ b/internal/incoming/odfi/processor_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestProcessor__process(t *testing.T) {
 	dir := t.TempDir()
-	if err := ioutil.WriteFile(filepath.Join(dir, "invalid.ach"), []byte("invalid-ach-file"), 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(dir, "invalid.ach"), []byte("invalid-ach-file"), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/notify/email.go
+++ b/internal/notify/email.go
@@ -70,6 +70,7 @@ func setupGoMailClient(cfg *service.Email) (*gomail.Dialer, error) {
 	host, _, _ := net.SplitHostPort(uri.Host)
 	tlsConfig := &tls.Config{
 		ServerName: host,
+		MinVersion: tls.VersionTLS12,
 	}
 
 	skipVerify, _ := strconv.ParseBool(uri.Query().Get("insecure_skip_verify"))

--- a/internal/pipeline/merging.go
+++ b/internal/pipeline/merging.go
@@ -96,7 +96,7 @@ func (m *filesystemMerging) writeACHFile(xfer incoming.ACHFile) error {
 	os.MkdirAll(path, 0777)
 
 	path = filepath.Join(path, fmt.Sprintf("%s.ach", xfer.FileID))
-	if err := ioutil.WriteFile(path, buf.Bytes(), 0644); err != nil {
+	if err := ioutil.WriteFile(path, buf.Bytes(), 0600); err != nil {
 		return err
 	}
 
@@ -111,7 +111,7 @@ func (m *filesystemMerging) HandleCancel(cancel incoming.CancelACHFile) error {
 	path = filepath.Join(path, fmt.Sprintf("%s.ach", cancel.FileID))
 	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
 		// file doesn't exist, so write one
-		return ioutil.WriteFile(path+".canceled", nil, 0644)
+		return ioutil.WriteFile(path+".canceled", nil, 0600)
 	} else {
 		// move the existing file
 		return os.Rename(path, path+".canceled")
@@ -302,7 +302,7 @@ func saveMergedFile(dir string, file *ach.File) error {
 		return fmt.Errorf("unable to buffer ACH file: %v", err)
 	}
 	filename := filepath.Join(dir, fmt.Sprintf("%s.ach", hash(buf.Bytes())))
-	return ioutil.WriteFile(filename, buf.Bytes(), 0644)
+	return ioutil.WriteFile(filename, buf.Bytes(), 0600)
 }
 
 func hash(data []byte) string {

--- a/internal/pipeline/merging_test.go
+++ b/internal/pipeline/merging_test.go
@@ -33,7 +33,7 @@ func TestMerging__getNonCanceledMatches(t *testing.T) {
 	dir := t.TempDir()
 
 	write := func(filename string) string {
-		err := ioutil.WriteFile(filepath.Join(dir, filename), nil, 0644)
+		err := ioutil.WriteFile(filepath.Join(dir, filename), nil, 0600)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/test/upload_test.go
+++ b/internal/test/upload_test.go
@@ -193,6 +193,7 @@ func countEntries(file *ach.File) (out int) {
 }
 
 func randomACHFile(t *testing.T) *ach.File {
+	//nolint:gosec
 	if rand.Int31()%2 == 0 {
 		file, err := ach.ReadFile(filepath.Join("..", "..", "testdata", "ppd-debit.ach"))
 		require.NoError(t, err)
@@ -207,7 +208,9 @@ func randomACHFile(t *testing.T) *ach.File {
 }
 
 func traceNumber(routingNumber string) string {
-	v := fmt.Sprintf("%s%d", routingNumber, rand.Int63n(1e15))
+	// nolint:gosec
+	num := rand.Int63n(1e15)
+	v := fmt.Sprintf("%s%d", routingNumber, num)
 	if utf8.RuneCountInString(v) > 15 {
 		return v[:15]
 	}

--- a/internal/upload/ftp.go
+++ b/internal/upload/ftp.go
@@ -124,7 +124,8 @@ func tlsDialOption(caFilePath string) (*ftp.DialOption, error) {
 		return nil, fmt.Errorf("tlsDialOption: problem with AppendCertsFromPEM from %s", caFilePath)
 	}
 	cfg := &tls.Config{
-		RootCAs: pool,
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
 	}
 	opt := ftp.DialWithTLS(cfg)
 	return &opt, nil

--- a/internal/upload/sftp.go
+++ b/internal/upload/sftp.go
@@ -131,6 +131,7 @@ func sftpConnect(logger log.Logger, cfg service.UploadAgent) (*ssh.Client, io.Wr
 		hostKeyCallbackOnce.Do(func() {
 			hostKeyCallback(logger)
 		})
+		//nolint:gosec
 		conf.HostKeyCallback = ssh.InsecureIgnoreHostKey() // insecure default
 	}
 	switch {


### PR DESCRIPTION
To better secure our codebases we're going to enable [gosec via golangci-lint](https://golangci-lint.run/usage/linters/#gosec) in CI. 