### PR TITLE
Pass in config transform to stream service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ pkged.go
 /storage-*/
 /testdata/ftp-server/outbound/*.ach
 /internal/test/storage/
+
+.idea/

--- a/internal/events/service_stream.go
+++ b/internal/events/service_stream.go
@@ -45,7 +45,8 @@ func newStreamService(logger log.Logger, transformConfig *models.TransformConfig
 		return nil, fmt.Errorf("events stream: %v", err)
 	}
 	return &streamService{
-		topic: topic,
+		topic:           topic,
+		transformConfig: transformConfig,
 	}, nil
 }
 


### PR DESCRIPTION
# Changes

We need to pass in the `TransformConfig` param as part of the `streamService` struct

# Why Are Changes Being Made

Events being emitted are unencrypted. This patch will properly encrypt events.