### PR TITLE
incoming/odfi: optionally store files in audit trail config

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -64,6 +64,14 @@ ACHGateway:
       TLS: <boolean>
       AutoCommit: <boolean>
     ODFI:
+      Audit:
+        ID: <string>
+        BucketURI: <string>
+        GPG:
+          KeyFile: <string>
+          Signer:
+            KeyFile: <string>
+            KeyPassword: <string>
       Processors:
         Corrections:
           Enabled: <boolean>
@@ -128,6 +136,14 @@ ACHGateway:
               KeyPassword: <string>
         UploadAgent: <string>
         OutboundFilenameTemplate: <string>
+        Audit:
+          ID: <string>
+          BucketURI: <string>
+          GPG:
+            KeyFile: <string>
+            Signer:
+              KeyFile: <string>
+              KeyPassword: <string>
         Output:
           Format: <string>
         Notifications:
@@ -150,14 +166,6 @@ ACHGateway:
           Retry:
             Interval: <duration>
             MaxRetries: <integer>
-        Audit:
-          - ID: <string>
-            BucketURI: <string>
-            GPG:
-              KeyFile: <string>
-              Signer:
-                KeyFile: <string>
-                KeyPassword: <string>
 ```
 
 ### Upload Agents
@@ -215,18 +223,6 @@ ACHGateway:
 ```yaml
   Notifications:
     # TODO(adam)
-```
-
-### Audit Trail
-```yaml
-  AuditTrail:
-    - ID: <string>
-      BucketURI: <string>
-      GPG:
-        KeyFile: <string>
-        Signer:
-          KeyFile: <string>
-          KeyPassword: <string>
 ```
 
 ### Error Alerting

--- a/go.sum
+++ b/go.sum
@@ -435,6 +435,7 @@ github.com/hashicorp/consul/api v1.8.1/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+Xbo
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.3.0 h1:UOxjlb4xVNF93jak1mzzoBatyFju9nrkxpVwIp/QqxQ=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/consul/sdk v0.7.0 h1:H6R9d008jDcHPQPAqPNuydAshJ4v5/8URdFnUvK/+sc=
 github.com/hashicorp/consul/sdk v0.7.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -477,6 +478,7 @@ github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0m
 github.com/hashicorp/mdns v1.0.1/go.mod h1:4gW7WsVCke5TE7EPeYliwHlRUyBtfCwuFwuMg2DmyNY=
 github.com/hashicorp/memberlist v0.1.3 h1:EmmoJme1matNzb+hMpDuR/0sbJSUisxyqBGG676r31M=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
+github.com/hashicorp/memberlist v0.2.2 h1:5+RffWKwqJ71YPu9mWsF7ZOscZmwfasdA8kbdC7AO2g=
 github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/serf v0.8.2 h1:YZ7UKsJv+hKjqGVUUbtE3HNj79Eln2oQ75tniF6iPt0=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
@@ -631,6 +633,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14 h1:9jZdLNd/P4+SfEJ0TNyxYpsK8N4GtfylBLqtbYN1sbA=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/dns v1.1.26 h1:gPxPSwALAeHJSjarOs00QjVdV9QoBvc1D2ujQUr5BzU=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/minio/highwayhash v1.0.1/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/minio/minio-go/v6 v6.0.46 h1:waExJtO53xrnsNX//7cSc1h3478wqTryDx4RVD7o26I=

--- a/internal/audittrail/storage.go
+++ b/internal/audittrail/storage.go
@@ -19,12 +19,12 @@ var (
 	uploadedFilesCounter = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 		Name: "audittrail_uploaded_files",
 		Help: "Counter of ACH files uploaded to audit trail storage",
-	}, []string{"type"})
+	}, []string{"type", "id"})
 
 	uploadFilesErrors = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 		Name: "audittrail_upload_errors",
 		Help: "Counter of errors encountered when attempting ACH files upload",
-	}, []string{"type"})
+	}, []string{"type", "id"})
 )
 
 // Storage is an interface for saving and encrypting ACH files for
@@ -33,7 +33,7 @@ var (
 // File retention after upload is not part of this storage.
 type Storage interface {
 	// SaveFile will encrypt and copy the ACH file to the configured file storage.
-	SaveFile(hostname, filename string, file *ach.File) error
+	SaveFile(filepath string, file *ach.File) error
 
 	GetFile(filepath string) (io.ReadCloser, error)
 

--- a/internal/audittrail/storage_blob.go
+++ b/internal/audittrail/storage_blob.go
@@ -83,6 +83,15 @@ func (bs *blobStorage) SaveFile(filepath string, file *ach.File) error {
 		return err
 	}
 
+	exists, err := bs.bucket.Exists(context.Background(), filepath)
+	if exists {
+		return nil
+	}
+	if err != nil {
+		uploadFilesErrors.With("type", "blob", "id", bs.id).Add(1)
+		return err
+	}
+
 	w, err := bs.bucket.NewWriter(context.Background(), filepath, nil)
 	if err != nil {
 		uploadFilesErrors.With("type", "blob", "id", bs.id).Add(1)

--- a/internal/audittrail/storage_blob.go
+++ b/internal/audittrail/storage_blob.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/moov-io/ach"
 	"github.com/moov-io/achgateway/internal/gpgx"
@@ -29,6 +28,7 @@ import (
 // blobStorage implements Storage with gocloud.dev/blob which allows
 // clients to use AWS S3, GCP Storage, and Azure Storage.
 type blobStorage struct {
+	id              string
 	bucket          *blob.Bucket
 	outputFormatter *output.NACHA
 	pubKey          openpgp.EntityList
@@ -36,6 +36,7 @@ type blobStorage struct {
 
 func newBlobStorage(cfg *service.AuditTrail) (*blobStorage, error) {
 	storage := &blobStorage{
+		id:              cfg.ID,
 		outputFormatter: &output.NACHA{},
 	}
 
@@ -54,8 +55,8 @@ func newBlobStorage(cfg *service.AuditTrail) (*blobStorage, error) {
 	}
 
 	// set default values for metrics
-	uploadFilesErrors.With("type", "blob").Add(0)
-	uploadedFilesCounter.With("type", "blob").Add(0)
+	uploadFilesErrors.With("type", "blob", "id", cfg.ID).Add(0)
+	uploadedFilesCounter.With("type", "blob", "id", cfg.ID).Add(0)
 
 	return storage, nil
 }
@@ -67,26 +68,24 @@ func (bs *blobStorage) Close() error {
 	return bs.bucket.Close()
 }
 
-func (bs *blobStorage) SaveFile(hostname, filename string, file *ach.File) error {
+func (bs *blobStorage) SaveFile(filepath string, file *ach.File) error {
 	result := &transform.Result{File: file}
 
 	var buf bytes.Buffer
 	if err := bs.outputFormatter.Format(&buf, result); err != nil {
-		uploadFilesErrors.With("type", "blob").Add(1)
+		uploadFilesErrors.With("type", "blob", "id", bs.id).Add(1)
 		return err
 	}
 
 	encrypted, err := gpgx.Encrypt(buf.Bytes(), bs.pubKey)
 	if err != nil {
-		uploadFilesErrors.With("type", "blob").Add(1)
+		uploadFilesErrors.With("type", "blob", "id", bs.id).Add(1)
 		return err
 	}
 
-	// write the file in a sub-path of the yyy-mm-dd
-	path := fmt.Sprintf("files/%s/%s/%s", hostname, time.Now().Format("2006-01-02"), filename)
-	w, err := bs.bucket.NewWriter(context.Background(), path, nil)
+	w, err := bs.bucket.NewWriter(context.Background(), filepath, nil)
 	if err != nil {
-		uploadFilesErrors.With("type", "blob").Add(1)
+		uploadFilesErrors.With("type", "blob", "id", bs.id).Add(1)
 		return err
 	}
 
@@ -94,12 +93,12 @@ func (bs *blobStorage) SaveFile(hostname, filename string, file *ach.File) error
 	closeErr := w.Close()
 
 	if copyErr != nil || closeErr != nil {
-		uploadFilesErrors.With("type", "blob").Add(1)
+		uploadFilesErrors.With("type", "blob", "id", bs.id).Add(1)
 		return fmt.Errorf("copyErr=%v closeErr=%v", copyErr, closeErr)
 	}
 
 	// increment our metrics counter
-	uploadedFilesCounter.With("type", "blob").Add(1)
+	uploadedFilesCounter.With("type", "blob", "id", bs.id).Add(1)
 
 	return nil
 }

--- a/internal/audittrail/storage_blob_test.go
+++ b/internal/audittrail/storage_blob_test.go
@@ -6,11 +6,9 @@ package audittrail
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/moov-io/ach"
 	"github.com/moov-io/achgateway/internal/service"
@@ -36,12 +34,11 @@ func TestBlobStorage(t *testing.T) {
 	file, err := ach.ReadFile(ppdPath)
 	require.NoError(t, err)
 
-	if err := store.SaveFile("ftp.dev.com", "saved.ach", file); err != nil {
+	if err := store.SaveFile("ftp.dev.com/saved.ach", file); err != nil {
 		t.Fatal(err)
 	}
 
-	path := fmt.Sprintf("files/ftp.dev.com/%s/saved.ach", time.Now().Format("2006-01-02"))
-	r, err := store.GetFile(path)
+	r, err := store.GetFile("ftp.dev.com/saved.ach")
 	require.NoError(t, err)
 	defer r.Close()
 

--- a/internal/audittrail/storage_mock.go
+++ b/internal/audittrail/storage_mock.go
@@ -19,8 +19,8 @@ type MockStorage struct {
 
 func newMockStorage() *MockStorage {
 	// default values for metrics
-	uploadFilesErrors.With("type", "mock").Add(0)
-	uploadedFilesCounter.With("type", "mock").Add(0)
+	uploadFilesErrors.With("type", "mock", "id", "mock").Add(0)
+	uploadedFilesCounter.With("type", "mock", "id", "mock").Add(0)
 
 	return &MockStorage{}
 }
@@ -29,11 +29,11 @@ func (s *MockStorage) Close() error {
 	return s.Err
 }
 
-func (s *MockStorage) SaveFile(hostname, filename string, file *ach.File) error {
+func (s *MockStorage) SaveFile(filepath string, file *ach.File) error {
 	if s.Err != nil {
-		uploadFilesErrors.With("type", "mock").Add(1)
+		uploadFilesErrors.With("type", "mock", "id", "mock").Add(1)
 	} else {
-		uploadedFilesCounter.With("type", "mock").Add(1)
+		uploadedFilesCounter.With("type", "mock", "id", "mock").Add(1)
 	}
 	return s.Err
 }

--- a/internal/incoming/odfi/processor_test.go
+++ b/internal/incoming/odfi/processor_test.go
@@ -21,6 +21,8 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+
+	"github.com/moov-io/achgateway/internal/audittrail"
 )
 
 func TestProcessor__process(t *testing.T) {
@@ -30,11 +32,15 @@ func TestProcessor__process(t *testing.T) {
 	}
 
 	processors := SetupProcessors(&MockProcessor{})
+	auditSaver := &AuditSaver{
+		storage:  &audittrail.MockStorage{},
+		hostname: "ftp.foo.com",
+	}
 
 	// By reading a file without ACH FileHeaders we still want to try and process
 	// Batches inside of it if any are found, so reading this kind of file shouldn't
 	// return an error from reading the file.
-	if err := process(dir, processors); err != nil {
+	if err := process(dir, auditSaver, processors); err != nil {
 		t.Error(err)
 	}
 }

--- a/internal/pipeline/aggregate.go
+++ b/internal/pipeline/aggregate.go
@@ -235,7 +235,8 @@ func (xfagg *aggregator) uploadFile(index int, agent upload.Agent, res *transfor
 	}
 
 	// Record the file in our audit trail
-	if err := xfagg.auditStorage.SaveFile(agent.Hostname(), filename, res.File); err != nil {
+	path := fmt.Sprintf("outbound/%s/%s/%s", agent.Hostname(), time.Now().Format("2006-01-02"), filename)
+	if err := xfagg.auditStorage.SaveFile(path, res.File); err != nil {
 		uploadFilesErrors.With().Add(1)
 		return fmt.Errorf("problem saving file in audit record: %v", err)
 	}

--- a/internal/service/model_inbound.go
+++ b/internal/service/model_inbound.go
@@ -30,6 +30,7 @@ type Inbound struct {
 	InMem *InMemory
 	Kafka *KafkaConfig
 	ODFI  *ODFIFiles
+	Audit *AuditTrail
 }
 
 func (cfg Inbound) Validate() error {
@@ -98,6 +99,7 @@ type ODFIFiles struct {
 	Interval   time.Duration
 	ShardNames []string
 	Storage    ODFIStorage
+	Audit      *AuditTrail
 }
 
 func (cfg *ODFIFiles) Validate() error {


### PR DESCRIPTION
This change will support storing inbound ODFI files (returns, corrections, etc) in an audittrail configuration. Doing so allows much better operational support for teams. 

Also:
- pipeline: save uploaded files under "outbound/" root path

Issue: https://github.com/moov-io/achgateway/issues/26