### PR TITLE
incoming/odfi: save the ODFI files exactly are they are downloaded

### DIFF
--- a/internal/audittrail/storage.go
+++ b/internal/audittrail/storage.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"io"
 
-	"github.com/moov-io/ach"
 	"github.com/moov-io/achgateway/internal/service"
 
 	"github.com/go-kit/kit/metrics/prometheus"
@@ -33,7 +32,7 @@ var (
 // File retention after upload is not part of this storage.
 type Storage interface {
 	// SaveFile will encrypt and copy the ACH file to the configured file storage.
-	SaveFile(filepath string, file *ach.File) error
+	SaveFile(filepath string, data []byte) error
 
 	GetFile(filepath string) (io.ReadCloser, error)
 

--- a/internal/audittrail/storage_blob_test.go
+++ b/internal/audittrail/storage_blob_test.go
@@ -10,14 +10,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/moov-io/ach"
 	"github.com/moov-io/achgateway/internal/service"
 	"github.com/stretchr/testify/require"
 )
 
 var (
 	keyPath = filepath.Join("..", "..", "internal", "gpgx", "testdata", "moov.pub")
-	ppdPath = filepath.Join("..", "..", "testdata", "ppd-debit.ach")
 )
 
 func TestBlobStorage(t *testing.T) {
@@ -31,10 +29,8 @@ func TestBlobStorage(t *testing.T) {
 	require.NoError(t, err)
 	defer store.Close()
 
-	file, err := ach.ReadFile(ppdPath)
-	require.NoError(t, err)
-
-	if err := store.SaveFile("ftp.dev.com/saved.ach", file); err != nil {
+	data := []byte("nacha formatted data")
+	if err := store.SaveFile("ftp.dev.com/saved.ach", data); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/audittrail/storage_mock.go
+++ b/internal/audittrail/storage_mock.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"strings"
-
-	"github.com/moov-io/ach"
 )
 
 type MockStorage struct {
@@ -29,7 +27,7 @@ func (s *MockStorage) Close() error {
 	return s.Err
 }
 
-func (s *MockStorage) SaveFile(filepath string, file *ach.File) error {
+func (s *MockStorage) SaveFile(_ string, _ []byte) error {
 	if s.Err != nil {
 		uploadFilesErrors.With("type", "mock", "id", "mock").Add(1)
 	} else {
@@ -38,7 +36,7 @@ func (s *MockStorage) SaveFile(filepath string, file *ach.File) error {
 	return s.Err
 }
 
-func (s *MockStorage) GetFile(filepath string) (io.ReadCloser, error) {
+func (s *MockStorage) GetFile(_ string) (io.ReadCloser, error) {
 	if s.Err != nil {
 		return nil, s.Err
 	}

--- a/internal/incoming/odfi/audit.go
+++ b/internal/incoming/odfi/audit.go
@@ -20,7 +20,6 @@ package odfi
 import (
 	"fmt"
 
-	"github.com/moov-io/ach"
 	"github.com/moov-io/achgateway/internal/audittrail"
 	"github.com/moov-io/achgateway/internal/service"
 )
@@ -30,14 +29,14 @@ type AuditSaver struct {
 	hostname string
 }
 
-func (as *AuditSaver) save(filepath string, file *ach.File) error {
+func (as *AuditSaver) save(filepath string, data []byte) error {
 	if as == nil {
 		return nil
 	}
-	return as.storage.SaveFile(filepath, file)
+	return as.storage.SaveFile(filepath, data)
 }
 
-func SaveFilesIntoAuditTrail(hostname string, cfg *service.AuditTrail) (*AuditSaver, error) {
+func newAuditSaver(hostname string, cfg *service.AuditTrail) (*AuditSaver, error) {
 	if cfg == nil {
 		return nil, nil
 	}

--- a/internal/incoming/odfi/scheduler.go
+++ b/internal/incoming/odfi/scheduler.go
@@ -135,7 +135,7 @@ func (s *PeriodicScheduler) tick(shard *service.Shard) error {
 	}
 
 	// Setup presistor files into our configured audit trail
-	auditSaver, err := SaveFilesIntoAuditTrail(agent.Hostname(), s.odfi.Audit)
+	auditSaver, err := newAuditSaver(agent.Hostname(), s.odfi.Audit)
 	if err != nil {
 		return fmt.Errorf("ERROR: %v", err)
 	}

--- a/internal/pipeline/aggregate.go
+++ b/internal/pipeline/aggregate.go
@@ -236,7 +236,7 @@ func (xfagg *aggregator) uploadFile(index int, agent upload.Agent, res *transfor
 
 	// Record the file in our audit trail
 	path := fmt.Sprintf("outbound/%s/%s/%s", agent.Hostname(), time.Now().Format("2006-01-02"), filename)
-	if err := xfagg.auditStorage.SaveFile(path, res.File); err != nil {
+	if err := xfagg.auditStorage.SaveFile(path, buf.Bytes()); err != nil {
 		uploadFilesErrors.With().Add(1)
 		return fmt.Errorf("problem saving file in audit record: %v", err)
 	}

--- a/internal/transform/preupload.go
+++ b/internal/transform/preupload.go
@@ -14,6 +14,7 @@ import (
 
 type Result struct {
 	File      *ach.File
+	Original  []byte
 	Encrypted []byte
 }
 


### PR DESCRIPTION
Some ODFI files arrive as partial Nacha compliant files and can't be properly marshaled, but regardless we should save those files exactly as they arrive to us. Going through a read -> write cycle could modify the file from their original bytes. 