### PR TITLE
notify: improve formatting of values in emails and slack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	gocloud.dev/pubsub/kafkapubsub v0.23.0
 	goftp.io/server v0.4.1
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
+	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/api v0.57.0 // indirect
 	google.golang.org/genproto v0.0.0-20210916144049-3192f974c780 // indirect
 )

--- a/internal/notify/email.go
+++ b/internal/notify/email.go
@@ -33,8 +33,8 @@ type EmailTemplateData struct {
 	Filename    string // e.g. 20200529-131400.ach
 	Hostname    string
 
-	DebitTotal  float64
-	CreditTotal float64
+	DebitTotal  string
+	CreditTotal string
 
 	BatchCount int
 	EntryCount int
@@ -130,10 +130,6 @@ func marshalEmail(cfg *service.Email, msg *Message) (string, error) {
 		return "", err
 	}
 	return buf.String(), nil
-}
-
-func convertDollar(in int) float64 {
-	return float64(in) / 100.0
 }
 
 func sendEmail(cfg *service.Email, dialer *gomail.Dialer, filename, body string) error {

--- a/internal/notify/helpers.go
+++ b/internal/notify/helpers.go
@@ -1,0 +1,13 @@
+package notify
+
+import (
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+	"golang.org/x/text/number"
+)
+
+func convertDollar(in int) string {
+	printer := message.NewPrinter(language.Und)
+	formatter := number.Decimal(float64(in)/100.0, number.MinFractionDigits(2))
+	return printer.Sprint(formatter)
+}

--- a/internal/notify/helpers_test.go
+++ b/internal/notify/helpers_test.go
@@ -1,0 +1,18 @@
+package notify
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertDollar(t *testing.T) {
+	require.Equal(t, "0.00", convertDollar(0))
+	require.Equal(t, "0.01", convertDollar(1))
+	require.Equal(t, "0.67", convertDollar(67))
+	require.Equal(t, "5.67", convertDollar(567))
+	require.Equal(t, "345.67", convertDollar(34567))
+	require.Equal(t, "2,345.67", convertDollar(234567))
+	require.Equal(t, "12,345.67", convertDollar(1234567))
+	require.Equal(t, "1,234,567.89", convertDollar(123456789))
+}

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -64,7 +64,7 @@ func marshalSlackMessage(status uploadStatus, msg *Message) string {
 	entries := countEntries(msg.File)
 	debitTotal := convertDollar(msg.File.Control.TotalDebitEntryDollarAmountInFile)
 	creditTotal := convertDollar(msg.File.Control.TotalCreditEntryDollarAmountInFile)
-	slackMsg += fmt.Sprintf("%d entries | Debits: %.2f | Credits: %.2f", entries, debitTotal, creditTotal)
+	slackMsg += fmt.Sprintf("%d entries | Debits: %s | Credits: %s", entries, debitTotal, creditTotal)
 
 	return slackMsg
 }

--- a/internal/service/model_notifications.go
+++ b/internal/service/model_notifications.go
@@ -28,8 +28,8 @@ var (
 	DefaultEmailTemplate = template.Must(template.New("email").Parse(`
 A file has been {{ .Verb }}ed{{ if .Hostname }}{{ if eq .Verb "upload" }} to{{ else }} from{{end}} {{ .Hostname }}{{end}} - {{ .Filename }}
 Name: {{ .CompanyName }}
-Debits:  ${{ .DebitTotal | printf "%.2f" }}
-Credits: ${{ .CreditTotal | printf "%.2f" }}
+Debits:  ${{ .DebitTotal }}
+Credits: ${{ .CreditTotal }}
 
 Batches: {{ .BatchCount }}
 Total Entries: {{ .EntryCount }}


### PR DESCRIPTION
# Changes
Values in emails and slack notifications don't contain commas which can lead people to scan and mis-read values. To better present clear values let's include commas following USD's typical formatting.

# Why Are Changes Being Made
To present values in a clearer manor for teams. 
