### PR TITLE
pipeline: add pending_files metric and include shard name

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -288,13 +288,28 @@ PayGate emits Prometheus metrics on the admin HTTP server at `/metrics`. Typical
 - `mysql_connections`: How many MySQL connections and what status they're in.
 - `sqlite_connections`: How many sqlite connections and what status they're in.
 
-### Inbound Files
+### ODFI Files
 
 - `correction_codes_processed`: Counter of correction (COR/NOC) files processed
 - `files_downloaded`: Counter of files downloaded from a remote server
 - `missing_return_transfers`: Counter of return EntryDetail records handled without a found transfer
 - `prenote_entries_processed`: Counter of prenote EntryDetail records processed
 - `return_entries_processed`: Counter of return EntryDetail records processed
+
+
+## Incoming Files
+
+- `incoming_http_files`: Counter of ACH files submitted through the http interface
+- `incoming_stream_files`: Counter of ACH files received through stream interface
+- `http_file_processing_errors`: Counter of http submitted ACH files that failed processing
+- `stream_file_processing_errors`: Counter of stream submitted ACH files that failed processing
+
+## Outbound Files
+
+- `pending_files`: Counter of ACH files waiting to be uploaded
+- `files_missing_shard_aggregators`: Counter of ACH files unable to be matched with a shard aggregator
+- `ach_uploaded_files`: Counter of ACH files uploaded through the pipeline to the ODFI
+- `ach_upload_errors`: Counter of errors encountered when attempting ACH files upload
 
 ### Remote File Servers
 

--- a/internal/pipeline/aggregate.go
+++ b/internal/pipeline/aggregate.go
@@ -271,9 +271,9 @@ func (xfagg *aggregator) uploadFile(index int, agent upload.Agent, res *transfor
 
 	// record our upload metrics
 	if err != nil {
-		uploadFilesErrors.With().Add(1)
+		uploadFilesErrors.With("shard", xfagg.shard.Name).Add(1)
 	} else {
-		uploadedFilesCounter.With().Add(1)
+		uploadedFilesCounter.With("shard", xfagg.shard.Name).Add(1)
 	}
 
 	return err

--- a/internal/pipeline/file_receiver.go
+++ b/internal/pipeline/file_receiver.go
@@ -175,9 +175,12 @@ func (fr *FileReceiver) handleMessage(ctx context.Context, sub *pubsub.Subscript
 				fr.logger.Error().LogErrorf("problem accepting file under shardName=%s", shardName)
 				out <- err
 			} else {
+				pendingFiles.With("shard", shardName).Add(1)
+
 				fr.logger.With(log.Fields{
 					"fileID": log.String(file.FileID),
 				}).Log("finished handling ACHFile")
+
 				cleanup()
 			}
 		} else {

--- a/internal/pipeline/file_receiver.go
+++ b/internal/pipeline/file_receiver.go
@@ -159,7 +159,7 @@ func (fr *FileReceiver) handleMessage(ctx context.Context, sub *pubsub.Subscript
 			if !exists {
 				agg, exists = fr.shardAggregators[fr.defaultShardName]
 				if !exists {
-					filesMissingShardAggregators.With().Add(1)
+					filesMissingShardAggregators.With("shard", shardName).Add(1)
 					fr.logger.Error().LogErrorf("missing shardAggregator for shardKey=%s shardName=%s", file.ShardKey, shardName)
 					cleanup()
 					return

--- a/internal/pipeline/metrics.go
+++ b/internal/pipeline/metrics.go
@@ -41,6 +41,10 @@ var (
 		Help: "Counter of stream submitted ACH files that failed processing",
 	}, nil)
 
+	pendingFiles = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+		Name: "pending_files",
+		Help: "Counter of ACH files waiting to be uploaded",
+	}, []string{"shard"})
 	filesMissingShardAggregators = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 		Name: "files_missing_shard_aggregators",
 		Help: "Counter of ACH files unable to be matched with a shard aggregator",

--- a/internal/pipeline/metrics.go
+++ b/internal/pipeline/metrics.go
@@ -48,16 +48,16 @@ var (
 	filesMissingShardAggregators = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 		Name: "files_missing_shard_aggregators",
 		Help: "Counter of ACH files unable to be matched with a shard aggregator",
-	}, nil)
+	}, []string{"shard"})
 
 	uploadedFilesCounter = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 		Name: "ach_uploaded_files",
 		Help: "Counter of ACH files uploaded through the pipeline to the ODFI",
-	}, nil)
+	}, []string{"shard"})
 	uploadFilesErrors = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 		Name: "ach_upload_errors",
 		Help: "Counter of errors encountered when attempting ACH files upload",
-	}, nil)
+	}, []string{"shard"})
 )
 
 func init() {
@@ -66,9 +66,4 @@ func init() {
 
 	httpFileProcessingErrors.With().Add(0)
 	streamFileProcessingErrors.With().Add(0)
-
-	filesMissingShardAggregators.With().Add(0)
-
-	uploadedFilesCounter.With().Add(0)
-	uploadFilesErrors.With().Add(0)
 }


### PR DESCRIPTION
This helps us be more descriptive with metrics in dashboards. Currently the results are lumped together a bit too much. 