### PR TITLE
output: support CR+LF line endings

### DIFF
--- a/internal/output/base64.go
+++ b/internal/output/base64.go
@@ -11,17 +11,21 @@ import (
 	"github.com/moov-io/achgateway/internal/transform"
 )
 
-type Base64 struct{}
+type Base64 struct {
+	lineEnding string
+}
 
 // Format converts any encrypted bytes into standard Base64 encoding. If no encrypted
 // bytes are passed then the file is encoded with NACHA formatting and then Base64 encoded.
-func (*Base64) Format(buf *bytes.Buffer, res *transform.Result) error {
+func (b *Base64) Format(buf *bytes.Buffer, res *transform.Result) error {
 	if len(res.Encrypted) > 0 {
 		buf.WriteString(base64.StdEncoding.EncodeToString(res.Encrypted))
 	} else {
 		var buf2 bytes.Buffer
 
-		nacha := &NACHA{}
+		nacha := &NACHA{
+			lineEnding: b.lineEnding,
+		}
 		if err := nacha.Format(&buf2, res); err != nil {
 			return err
 		}

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -22,15 +22,26 @@ func NewFormatter(cfg *service.Output) (Formatter, error) {
 	if cfg == nil || cfg.Format == "" {
 		return &NACHA{}, nil
 	}
-	switch {
-	case strings.EqualFold(cfg.Format, "base64"):
-		return &Base64{}, nil
 
-	case strings.EqualFold(cfg.Format, "encrypted-bytes"):
+	format := strings.ToLower(cfg.Format)
+	lineEnding := "\n"
+	if strings.HasSuffix(format, "-crlf") {
+		lineEnding = "\r\n"
+	}
+
+	switch {
+	case strings.EqualFold(format, "encrypted-bytes"):
 		return &Encrypted{}, nil
 
-	case strings.EqualFold(cfg.Format, "nacha"):
-		return &NACHA{}, nil
+	case strings.HasPrefix(format, "base64"):
+		return &Base64{
+			lineEnding: lineEnding,
+		}, nil
+
+	case strings.HasPrefix(format, "nacha"):
+		return &NACHA{
+			lineEnding: lineEnding,
+		}, nil
 	}
 	return nil, errors.New("unknown output format")
 }

--- a/internal/output/nacha.go
+++ b/internal/output/nacha.go
@@ -12,10 +12,16 @@ import (
 	"github.com/moov-io/achgateway/internal/transform"
 )
 
-type NACHA struct{}
+type NACHA struct {
+	lineEnding string
+}
 
-func (*NACHA) Format(buf *bytes.Buffer, res *transform.Result) error {
-	if err := ach.NewWriter(buf).Write(res.File); err != nil {
+func (n *NACHA) Format(buf *bytes.Buffer, res *transform.Result) error {
+	w := ach.NewWriter(buf)
+	if n.lineEnding != "" {
+		w.LineEnding = n.lineEnding
+	}
+	if err := w.Write(res.File); err != nil {
 		return fmt.Errorf("unable to buffer ACH file: %v", err)
 	}
 	return nil

--- a/internal/output/nacha_test.go
+++ b/internal/output/nacha_test.go
@@ -43,3 +43,20 @@ func TestNACHA(t *testing.T) {
 		t.Errorf("unexpected output:\n%v", s)
 	}
 }
+
+func TestNacha__CRLF(t *testing.T) {
+	enc := &NACHA{
+		lineEnding: "\r\n",
+	}
+
+	var buf bytes.Buffer
+	res := testResult(t)
+
+	if err := enc.Format(&buf, res); err != nil {
+		t.Fatal(err)
+	}
+
+	if s := buf.String(); !strings.Contains(s, "\r\n") {
+		t.Errorf("unexpected output:\n%v", s)
+	}
+}


### PR DESCRIPTION
This change supports supplying "windows" line endings for ACH files that are uploaded. It only works for NACHA encoded files and their base64 transformations. 