### PR TITLE
upload: option to ensuring directories exist, request less permissions

### DIFF
--- a/internal/service/model_upload.go
+++ b/internal/service/model_upload.go
@@ -143,6 +143,10 @@ type SFTP struct {
 	DialTimeout           time.Duration
 	MaxConnectionsPerFile int
 	MaxPacketSize         int
+
+	// SkipDirectoryCreation will configure achgateway to create
+	// directories on the remote server prior to uploading files.
+	SkipDirectoryCreation bool
 }
 
 func (cfg *SFTP) MarshalJSON() ([]byte, error) {
@@ -157,6 +161,8 @@ func (cfg *SFTP) MarshalJSON() ([]byte, error) {
 		DialTimeout           time.Duration
 		MaxConnectionsPerFile int
 		MaxPacketSize         int
+
+		SkipDirectoryCreation bool
 	}
 	return json.Marshal(Aux{
 		Hostname: cfg.Hostname,
@@ -169,6 +175,8 @@ func (cfg *SFTP) MarshalJSON() ([]byte, error) {
 		DialTimeout:           cfg.DialTimeout,
 		MaxConnectionsPerFile: cfg.MaxConnectionsPerFile,
 		MaxPacketSize:         cfg.MaxPacketSize,
+
+		SkipDirectoryCreation: cfg.SkipDirectoryCreation,
 	})
 }
 

--- a/internal/upload/sftp.go
+++ b/internal/upload/sftp.go
@@ -318,7 +318,8 @@ func (agent *SFTPTransferAgent) UploadFile(f File) error {
 
 	// Take the base of f.Filename and our (out of band) OutboundPath to avoid accepting a write like '../../../../etc/passwd'.
 	pathToWrite := filepath.Join(agent.cfg.Paths.Outbound, filepath.Base(f.Filename))
-	fd, err := conn.Create(pathToWrite)
+
+	fd, err := conn.OpenFile(pathToWrite, os.O_WRONLY|os.O_CREATE|os.O_TRUNC)
 	if err != nil {
 		return fmt.Errorf("sftp: problem creating %s: %v", pathToWrite, err)
 	}

--- a/internal/upload/sftp.go
+++ b/internal/upload/sftp.go
@@ -317,9 +317,10 @@ func (agent *SFTPTransferAgent) UploadFile(f File) error {
 	}
 
 	// Take the base of f.Filename and our (out of band) OutboundPath to avoid accepting a write like '../../../../etc/passwd'.
-	fd, err := conn.Create(filepath.Join(agent.cfg.Paths.Outbound, filepath.Base(f.Filename)))
+	pathToWrite := filepath.Join(agent.cfg.Paths.Outbound, filepath.Base(f.Filename))
+	fd, err := conn.Create(pathToWrite)
 	if err != nil {
-		return fmt.Errorf("sftp: problem creating %s: %v", f.Filename, err)
+		return fmt.Errorf("sftp: problem creating %s: %v", pathToWrite, err)
 	}
 	n, err := io.Copy(fd, f.Contents)
 	if err != nil {

--- a/internal/upload/sftp.go
+++ b/internal/upload/sftp.go
@@ -306,11 +306,13 @@ func (agent *SFTPTransferAgent) UploadFile(f File) error {
 		return err
 	}
 
-	// Create OutboundPath if it doesn't exist
-	info, err := conn.Stat(agent.cfg.Paths.Outbound)
-	if info == nil || (err != nil && os.IsNotExist(err)) {
-		if err := conn.Mkdir(agent.cfg.Paths.Outbound); err != nil {
-			return fmt.Errorf("sftp: problem creating parent dir %s: %v", agent.cfg.Paths.Outbound, err)
+	// Create OutboundPath if it doesn't exist and we're told to create it
+	if agent.cfg.SFTP != nil && !agent.cfg.SFTP.SkipDirectoryCreation {
+		info, err := conn.Stat(agent.cfg.Paths.Outbound)
+		if info == nil || (err != nil && os.IsNotExist(err)) {
+			if err := conn.Mkdir(agent.cfg.Paths.Outbound); err != nil {
+				return fmt.Errorf("sftp: problem creating parent dir %s: %v", agent.cfg.Paths.Outbound, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
BREAKING CHANGE

This config will allow to disable directory creation on SFTP file uploads. Some servers have strict permissions which do not allow this. 