### PR TITLE
notify: retry temporary email send failures

### DIFF
--- a/internal/service/model_notifications.go
+++ b/internal/service/model_notifications.go
@@ -117,6 +117,7 @@ type Email struct {
 	//
 	// Example: smtps://user:pass@localhost:1025/?insecure_skip_verify=true
 	ConnectionURI string
+	MaxRetries    int
 
 	Template    string
 	CompanyName string


### PR DESCRIPTION
A basic retry strategy for when emails fail to send. 