### PR TITLE
incoming/stream: bump min kafka version to v2.6.0

### DIFF
--- a/internal/incoming/stream/kafka.go
+++ b/internal/incoming/stream/kafka.go
@@ -1,0 +1,24 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package stream
+
+import (
+	"github.com/Shopify/sarama"
+)
+
+var minKafkaVersion = sarama.V2_6_0_0

--- a/internal/incoming/stream/publisher.go
+++ b/internal/incoming/stream/publisher.go
@@ -37,7 +37,7 @@ func Topic(logger log.Logger, cfg *service.Config) (*pubsub.Topic, error) {
 
 func createKafkaTopic(logger log.Logger, cfg *service.KafkaConfig) (*pubsub.Topic, error) {
 	config := kafkapubsub.MinimalConfig()
-	config.Version = sarama.V2_5_0_0
+	config.Version = minKafkaVersion
 	config.Net.TLS.Enable = cfg.TLS
 
 	config.Net.SASL.Enable = cfg.Key != ""

--- a/internal/incoming/stream/subscription.go
+++ b/internal/incoming/stream/subscription.go
@@ -51,7 +51,7 @@ func Subscription(logger log.Logger, cfg *service.Config) (*pubsub.Subscription,
 
 func createKafkaSubscription(logger log.Logger, cfg *service.KafkaConfig) (*pubsub.Subscription, error) {
 	config := kafkapubsub.MinimalConfig()
-	config.Version = sarama.V2_5_0_0
+	config.Version = minKafkaVersion
 	config.Net.TLS.Enable = cfg.TLS
 
 	config.Net.SASL.Enable = cfg.Key != ""


### PR DESCRIPTION
v2.6.0 was released Aug 3, 2020

https://kafka.apache.org/downloads#2.6.0