### PR TITLE
pipeline: support passing ach merge conditions through

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -157,6 +157,12 @@ ACHGateway:
               KeyFile: <string>
               KeyPassword: <string>
         UploadAgent: <string>
+        Mergable:
+          # If Conditions is nil files are merged until reaching Nacha's limit of 10,000 lines
+          Conditions:
+            MaxLines: <integer>
+            MaxDollarAmount: <integer>
+          FlattenBatches: {}
         OutboundFilenameTemplate: <string>
         Audit:
           ID: <string>
@@ -235,7 +241,6 @@ ACHGateway:
       AllowedIPs: <string>
     Merging:
       Directory: <string>
-      FlattenBatches: {}
     Retry:
       Interval: <duration>
       MaxRetries: <integer>

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@ When a cutoff time is triggered there are several steps to be performed for each
 
 1. If self-elected leader
    1. Merge pending files (inside `storage/merging/:key/*.ach`) that do not contain a `*.canceled` file.
-      1. With moov-io/ach's `MergeFiles(...)` function
+      1. With moov-io/ach's `MergeFiles(...)` function (and optional `ach.Conditions` for max dollar amounts in a file, etc)
    1. Optionally `FlattenBatches()` on files and encrypt file contents (e.g. GPG)
    1. Render filename from template, prepare output formatting
    1. Save file to `uploaded/*.ach` inside of our `storage/merging/:key/` directory

--- a/go.mod
+++ b/go.mod
@@ -16,10 +16,16 @@ require (
 	github.com/PagerDuty/go-pagerduty v1.4.3
 	github.com/ProtonMail/go-crypto v0.0.0-20211112122917-428f8eabeeb3
 	github.com/Shopify/sarama v1.30.0
+	github.com/bketelsen/crypt v0.0.4 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec // indirect
 	github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe // indirect
 	github.com/cncf/xds/go v0.0.0-20220121163655-4a2b9fdd466b // indirect
+	github.com/cockroachdb/cockroach-go v0.0.0-20190925194419-606b3d062051 // indirect
+	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.6.7 // indirect
 	github.com/go-kit/kit v0.12.0
+	github.com/google/go-github v17.0.0+incompatible // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/go-replayers/grpcreplay v1.1.0 // indirect
 	github.com/google/go-replayers/httpreplay v1.0.0 // indirect
@@ -35,19 +41,22 @@ require (
 	github.com/minio/minio-go/v6 v6.0.57 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
-	github.com/moov-io/ach v1.13.0
+	github.com/moov-io/ach v1.15.0
 	github.com/moov-io/base v0.28.1
 	github.com/moov-io/cryptfs v0.1.0
 	github.com/ory/dockertest/v3 v3.8.1
 	github.com/ory/mail/v3 v3.0.0
+	github.com/performancecopilot/speed v3.0.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.0
 	github.com/prometheus/client_golang v1.12.1
+	github.com/rickar/cal v1.0.5 // indirect
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sethvargo/go-retry v0.1.0
+	github.com/snowflakedb/glog v0.0.0-20180824191149-f5055e6f21ce // indirect
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/objx v0.3.0 // indirect
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.1
 	gocloud.dev v0.23.0
 	gocloud.dev/pubsub/kafkapubsub v0.23.0
 	goftp.io/server v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,7 @@ github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-lambda-go v1.26.0/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
+github.com/aws/aws-lambda-go v1.31.1/go.mod h1:IF5Q7wj4VyZyUFnZ54IQqeWtctHQ9tz+KhcbDenr220=
 github.com/aws/aws-sdk-go v1.15.27/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -737,6 +738,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/ansiterm v0.0.0-20210706145210-9283cdf370b5/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
+github.com/juju/ansiterm v0.0.0-20210929141451-8b71cc96ebdc/go.mod h1:PyXUpnI3olx3bsPcHt98FGPX/KCFZ1Fi+hw1XLI6384=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
@@ -810,6 +812,7 @@ github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.10/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-ieproxy v0.0.1 h1:qiyop7gCflfhwCzGyeT0gro3sF9AIg9HU98JORTkqfI=
@@ -879,6 +882,10 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/moov-io/ach v1.13.0 h1:5FEzdKF40p9UNqaFRrR9dbFt6HwdRvkz/LHkFSHSgnk=
 github.com/moov-io/ach v1.13.0/go.mod h1:32m/asGe0k19Ued+8xuFQVg7Id+oURLKGNMA/XOPPtI=
+github.com/moov-io/ach v1.14.1-0.20220429184305-c0af4d34b2b6 h1:lwqliv7tiInYzBJE0iOJpjNo6Ioi8oKlSqSlIqZayGQ=
+github.com/moov-io/ach v1.14.1-0.20220429184305-c0af4d34b2b6/go.mod h1:xAhlVmBmv1XMozYgdQF5+ukfLBqBW2vw/YUdl0BjKOI=
+github.com/moov-io/ach v1.15.0 h1:jxZUH2F2VC2aa0mA5xs9YKlcbG+P0KAUkS8S4PzdsYA=
+github.com/moov-io/ach v1.15.0/go.mod h1:xAhlVmBmv1XMozYgdQF5+ukfLBqBW2vw/YUdl0BjKOI=
 github.com/moov-io/base v0.24.0/go.mod h1:0yrPUDvZnVnrgl0T5veVUwNnxEKGLRObjzxhwXrJV6U=
 github.com/moov-io/base v0.28.1 h1:aHgZm+zwSOq5UuNwtgZheNsFbhWEVOlME37uPbZ4CRk=
 github.com/moov-io/base v0.28.1/go.mod h1:OVxDhGHGrEdy5Z8KIyP4RCordjv9mm0wim0+Z9rg19k=
@@ -1085,6 +1092,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/internal/service/model_sharding.go
+++ b/internal/service/model_sharding.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/moov-io/ach"
 )
 
 var (
@@ -70,6 +72,7 @@ type Shard struct {
 	Cutoffs                  Cutoffs
 	PreUpload                *PreUpload
 	UploadAgent              string
+	Mergable                 MergableConfig
 	OutboundFilenameTemplate string
 	Output                   *Output
 	Notifications            *Notifications
@@ -137,6 +140,13 @@ func (cfg *PreUpload) Validate() error {
 	}
 	return nil
 }
+
+type MergableConfig struct {
+	Conditions     *ach.Conditions
+	FlattenBatches *FlattenBatches
+}
+
+type FlattenBatches struct{}
 
 type Output struct {
 	Format string

--- a/internal/service/model_upload.go
+++ b/internal/service/model_upload.go
@@ -229,11 +229,7 @@ type UploadNotifiers struct {
 type Merging struct {
 	Storage   storage.Config
 	Directory string // fallback config for Storage.Filesystem.Directory
-
-	FlattenBatches *FlattenBatches
 }
-
-type FlattenBatches struct{}
 
 type UploadRetry struct {
 	Interval   time.Duration


### PR DESCRIPTION
This allows Shards to further control merged file behavior, such as max dollar amounts per-file.

The change as-is will be a small breaking change. Flattening batches (and these merge conditions) should be configured on a shard level. Currently they're on a global level, but each ODFI is different. 

See: https://github.com/moov-io/ach/pull/1009