### PR TITLE
fix: enable diffie-hellman-group-exchange-sha256 ssh algorithm

### DIFF
--- a/internal/upload/sftp.go
+++ b/internal/upload/sftp.go
@@ -122,7 +122,14 @@ func sftpConnect(logger log.Logger, cfg service.UploadAgent) (*ssh.Client, io.Wr
 		return nil, nil, nil, errors.New("nil config or sftp config")
 	}
 
+	sshConf := ssh.Config{}
+	sshConf.SetDefaults()
+	sshConf.KeyExchanges = append(
+		sshConf.KeyExchanges,
+		"diffie-hellman-group-exchange-sha256",
+	)
 	conf := &ssh.ClientConfig{
+		Config:  sshConf,
 		User:    cfg.SFTP.Username,
 		Timeout: cfg.SFTP.Timeout(),
 	}


### PR DESCRIPTION
# Changes
- Enable diffie-hellman-group-exchange-sha256 ssh algorithm in the list of algorithms to be provided during a SFTP key exchange

# Why Are Changes Being Made
This follows the same approach from https://github.com/moov-io/paygate/issues/625 and refers to the sftp client from achgateway being unable to connect to certain partners