### PR TITLE
fix: save plaintext audit files when GPG isn't configured

### DIFF
--- a/internal/audittrail/storage_blob.go
+++ b/internal/audittrail/storage_blob.go
@@ -59,7 +59,13 @@ func (bs *blobStorage) Close() error {
 }
 
 func (bs *blobStorage) SaveFile(filepath string, data []byte) error {
-	encrypted, err := bs.cryptor.Disfigure(data)
+	var encrypted []byte
+	var err error
+	if bs.cryptor != nil {
+		encrypted, err = bs.cryptor.Disfigure(data)
+	} else {
+		encrypted = data
+	}
 	if err != nil {
 		uploadFilesErrors.With("type", "blob", "id", bs.id).Add(1)
 		return err

--- a/internal/audittrail/storage_blob_test.go
+++ b/internal/audittrail/storage_blob_test.go
@@ -45,6 +45,28 @@ func TestBlobStorage(t *testing.T) {
 	}
 }
 
+func TestBlobStorage__NoGPG(t *testing.T) {
+	cfg := &service.AuditTrail{
+		BucketURI: "mem://",
+	}
+
+	store, err := newBlobStorage(cfg)
+	require.NoError(t, err)
+	defer store.Close()
+
+	data := []byte("nacha formatted data")
+	err = store.SaveFile("ftp.dev.com/saved.ach", data)
+	require.NoError(t, err)
+
+	r, err := store.GetFile("ftp.dev.com/saved.ach")
+	require.NoError(t, err)
+	defer r.Close()
+
+	bs, err := ioutil.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, data, bs)
+}
+
 func TestBlobStorageErr(t *testing.T) {
 	cfg := &service.AuditTrail{
 		BucketURI: "bad://",


### PR DESCRIPTION
Fixes: https://github.com/moov-io/achgateway/issues/106 