### PR TITLE
feat: support canceling files over HTTP, fix handling of CancelACHFile

### DIFF
--- a/docs/concepts/submission.md
+++ b/docs/concepts/submission.md
@@ -23,7 +23,7 @@ There are two main methods for submitting files to ACHGateway: HTTP or stream. F
 
 ### HTTP
 
-ACHGateway has an endpoint for submitting a file to be queued.
+ACHGateway has an endpoint for submitting a file to be queued. Refer to the [endpoint docs](https://moov-io.github.io/achgateway/api/#post-/shards/-shardKey-/files/-fileID-) for more details.
 
 ```
 POST /shards/{shardKey}/files/{fileID}
@@ -52,15 +52,6 @@ Submit `QueueACHFile` events:
 }
 ```
 
-Or `CancelACHFile` to cancel previously submitted files:
-
-```
-{
-  "id": "uuid",
-  "shardKey": "uuid"
-}
-```
-
 #### Notes
 
 Make sure to understand the implications of enabling/disabling consumer groups with your kafka subscription and multiple instances of ACHGateway.
@@ -84,6 +75,27 @@ After pending files are uploaded to the remote server a `FileUploaded` event is 
 }
 ```
 
-## Additional Notes
+# Canceling Files
+
+### HTTP
+
+Make an HTTP request to cancel the file. This request can be made before the file is submitted to ACHGateway. Refer to the [endpoint docs](https://moov-io.github.io/achgateway/api/#delete-/shards/-shardKey-/files/-fileID-) for more details.
+
+```
+DELETE /shards/{shardKey}/files/{fileID}
+```
+
+### Stream
+
+Publish an `CancelACHFile` event to cancel a submitted file. The canceling can arrive before the `QueueACHFile` event and will still cancel the file.
+
+```
+{
+  "id": "uuid",
+  "shardKey": "uuid"
+}
+```
+
+# Additional Notes
 
 - Refer to the [merging operations](../../ops/merging/) page for more details on pending file storage.

--- a/internal/pipeline/aggregate.go
+++ b/internal/pipeline/aggregate.go
@@ -165,6 +165,10 @@ func (xfagg *aggregator) acceptFile(msg incoming.ACHFile) error {
 	return xfagg.merger.HandleXfer(msg)
 }
 
+func (xfagg *aggregator) cancelFile(msg incoming.CancelACHFile) error {
+	return xfagg.merger.HandleCancel(msg)
+}
+
 func (xfagg *aggregator) withEachFile(when time.Time) error {
 	window := when.Format("15:04")
 	tzname, _ := when.Zone()

--- a/internal/storage/filesystem.go
+++ b/internal/storage/filesystem.go
@@ -67,7 +67,7 @@ func (fs *filesystem) Glob(pattern string) ([]FileStat, error) {
 
 func (fs *filesystem) ReplaceFile(oldpath, newpath string) error {
 	oldpath = filepath.Join(fs.root, oldpath)
-	newpath = filepath.Join(fs.root, newpath+".canceled")
+	newpath = filepath.Join(fs.root, newpath)
 
 	// Create the new dir(s)
 	dir, _ := filepath.Split(newpath)
@@ -77,7 +77,7 @@ func (fs *filesystem) ReplaceFile(oldpath, newpath string) error {
 
 	// file doesn't exist, so write newpath
 	if _, err := os.Stat(oldpath); err != nil && os.IsNotExist(err) {
-		return ioutil.WriteFile(filepath.Join(fs.root, newpath), nil, 0600)
+		return ioutil.WriteFile(newpath, nil, 0600)
 	}
 
 	// move the existing file

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -29,7 +29,7 @@ func testStorage(t *testing.T, chest Chest) {
 	// replace file
 	err = chest.WriteFile("test-20210101-0101/foo.ach", []byte("nacha"))
 	require.NoError(t, err)
-	err = chest.ReplaceFile("test-20210101-0101/foo.ach", "after/foo.ach")
+	err = chest.ReplaceFile("test-20210101-0101/foo.ach", "after/foo.ach.canceled")
 	require.NoError(t, err)
 	file, err = chest.Open("after/foo.ach.canceled")
 	require.NoError(t, err)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -79,6 +79,31 @@ paths:
           description: Unable to read file, make sure the file is in either valid Nacha or moov-io/ach formatting.
         '500':
           description: Error publishing the file. Check logs for publishing errors.
+    delete:
+      description: Cancel a pending ACH file
+      tags: [ "Files" ]
+      operationId: cancelFile
+      servers:
+        - url: http://localhost:8484
+          description: Business Logic
+      parameters:
+        - name: shardKey
+          in: path
+          required: true
+          schema:
+            type: string
+            example: "testing"
+        - name: fileID
+          in: path
+          required: true
+          schema:
+            type: string
+            example: AE694B55-C103-4FA5-B62E-E4F6F79AD581
+      responses:
+        '200':
+          description: File accepted successfully without errors.
+        '500':
+          description: Error canceling the file. Check logs for publishing errors.
 
   /shards/{shardName}/files:
     get:

--- a/pkg/models/events_test.go
+++ b/pkg/models/events_test.go
@@ -62,6 +62,27 @@ func TestEvent(t *testing.T) {
 	}, `"type":"FileUploaded"`)
 }
 
+func TestRead(t *testing.T) {
+	orig := CancelACHFile{
+		FileID:   base.ID(),
+		ShardKey: base.ID(),
+	}
+
+	bs := (Event{
+		Event: orig,
+	}).Bytes()
+
+	second, err := Read(bs)
+	require.NoError(t, err)
+	require.Equal(t, "CancelACHFile", second.Type)
+
+	cancel, ok := second.Event.(*CancelACHFile)
+	require.True(t, ok)
+
+	require.Equal(t, orig.FileID, cancel.FileID)
+	require.Equal(t, orig.ShardKey, cancel.ShardKey)
+}
+
 func TestPartialReconciliationFile(t *testing.T) {
 	file, err := ach.ReadFile(filepath.Join("testdata", "partial-recon.ach"))
 	require.NotNil(t, err)


### PR DESCRIPTION
When adding the endpoint for canceling a file I noticed that those events weren't getting fully processed. 