### PR TITLE
Hotfix/env variable folder names

### DIFF
--- a/internal/incoming/odfi/processor.go
+++ b/internal/incoming/odfi/processor.go
@@ -26,7 +26,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/moov-io/ach"
 	"github.com/moov-io/base"
 
 	"github.com/go-kit/kit/metrics/prometheus"
@@ -158,7 +157,7 @@ func processFile(path string, auditSaver *AuditSaver, fileProcessors Processors)
 	}
 	// Persist the file if needed
 	if auditSaver != nil {
-		path := fmt.Sprintf("%s/%s/%s/%s/%s", rdfiFolder, auditSaver.hostname, dir, time.Now().Format("2006-01-02"), filename)
+		path := fmt.Sprintf("%s/%s/%s/%s/%s", rdfiFolder, auditSaver.hostname, time.Now().Format("2006-01-02"), dir, filename)
 		err = auditSaver.save(path, bs)
 		if err != nil {
 			return fmt.Errorf("audittrail %s error: %v", path, err)

--- a/internal/incoming/odfi/processor.go
+++ b/internal/incoming/odfi/processor.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"time"
@@ -150,9 +151,14 @@ func processFile(path string, auditSaver *AuditSaver, fileProcessors Processors)
 	dir, filename := filepath.Split(path)
 	dir = filepath.Base(dir)
 
+	// default to old file structure if no env variable is present
+	rdfiFolder := "odfi"
+	if rf := os.Getenv("RDFI_FOLDER"); rf != "" {
+		rdfiFolder = rf
+	}
 	// Persist the file if needed
 	if auditSaver != nil {
-		path := fmt.Sprintf("odfi/%s/%s/%s/%s", auditSaver.hostname, dir, time.Now().Format("2006-01-02"), filename)
+		path := fmt.Sprintf("%s/%s/%s/%s/%s", rdfiFolder, auditSaver.hostname, dir, time.Now().Format("2006-01-02"), filename)
 		err = auditSaver.save(path, bs)
 		if err != nil {
 			return fmt.Errorf("audittrail %s error: %v", path, err)

--- a/internal/pipeline/aggregate.go
+++ b/internal/pipeline/aggregate.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	ach_v1_18_5 "github.com/moov-io/ach"
 	"github.com/moov-io/achgateway/internal/alerting"
 	"github.com/moov-io/achgateway/internal/audittrail"
 	"github.com/moov-io/achgateway/internal/consul"
@@ -234,7 +233,7 @@ func (xfagg *aggregator) emitFilesUploaded(proc *processedFiles) error {
 	return el
 }
 
-func (xfagg *aggregator) runTransformers(index int, agent upload.Agent, outgoing *ach_v1_18_5.File) error {
+func (xfagg *aggregator) runTransformers(index int, agent upload.Agent, outgoing *ach.File) error {
 	result, err := transform.ForUpload(outgoing, xfagg.preuploadTransformers)
 	if err != nil {
 		return err
@@ -302,7 +301,7 @@ func prepareShardName(shardName string) string {
 	return strings.ToUpper(strings.ReplaceAll(shardName, " ", "-"))
 }
 
-func (xfagg *aggregator) notifyAfterUpload(filename string, file *ach_v1_18_5.File, agent upload.Agent, uploadErr error) error {
+func (xfagg *aggregator) notifyAfterUpload(filename string, file *ach.File, agent upload.Agent, uploadErr error) error {
 	msg := &notify.Message{
 		Direction: notify.Upload,
 		Filename:  filename,


### PR DESCRIPTION
# Changes
A quick way to make folder structure in s3 compatible storage configurable

# Why Are Changes Being Made
So you can customize what your folders are named so this adds two env variables

`ODFI_FOLDER`

And

`RDFI_FOLDER` 

If you leave them blank or do not set them it will default to the original paths so this is backwards compatible

I did make a tweak to the path so that it is ALWAYS 

`{NAME}/{SFTP}/{DATE}/{DIRECTORY}/{FILE}`

instead of

`{NAME}/{SFTP}/{DIRECTORY}/{DATE}/{FILE}`

because it was a bit frustrating to have to navigate another folder level deep to see which files were for which days, figured this would be easier for most people if done this way as I could not see a reasonably good reason to have the directory names be ahead of the dates, but if that's incorrect happy to chat about it

The other open question would be whether you need the directory at all. If you did away with the directory it would mirror the way outgoing files are saved in s3 compatible storage which might be nice, but i'm not sure why it was originally chosen so I do not want to make assumptions without learnings