### PR TITLE
pipeline: skip uploading files after caching fails

### DIFF
--- a/internal/pipeline/merging.go
+++ b/internal/pipeline/merging.go
@@ -289,6 +289,8 @@ func (m *filesystemMerging) WithEachMerged(f func(int, upload.Agent, *ach.File) 
 		// Write our file to the mergable directory
 		if err := m.saveMergedFile(dir, files[i]); err != nil {
 			el.Add(fmt.Errorf("problem writing merged file: %v", err))
+			logger.Error().Logf("skipping upload of %s after cache failure", files[i])
+			continue // skip upload if we can't cache what to upload
 		}
 
 		// Perform the file upload if we are the shard leader
@@ -302,6 +304,7 @@ func (m *filesystemMerging) WithEachMerged(f func(int, upload.Agent, *ach.File) 
 		} else {
 			logger.Info().Log("we are the leader")
 
+			// Upload the file
 			if err := f(i, agent, files[i]); err != nil {
 				el.Add(fmt.Errorf("problem from callback: %v", err))
 			} else {


### PR DESCRIPTION
It's been brought up that if we're unable to "cache" files in uploaded/ then we shouldn't try to upload them.

I'm undecided with this change because if we can continue uploading then the results can be evented, on the audittrail and/or on the remote server.

However if we cannot upload elsewhere in addition to the cache then deeper problems should be fixed.

