### PR TITLE
chore: bubble up error

### DIFF
--- a/internal/pipeline/file_receiver.go
+++ b/internal/pipeline/file_receiver.go
@@ -20,6 +20,7 @@ package pipeline
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/moov-io/achgateway/internal/incoming"
@@ -229,8 +230,7 @@ func (fr *FileReceiver) processMessage(msg *pubsub.Message) error {
 		return nil
 	}
 
-	fr.logger.Error().LogErrorf("unexpected %T event", event.Event)
-	return nil
+	return fmt.Errorf("unexpected %T event", event.Event)
 }
 
 func (fr *FileReceiver) getAggregator(shardKey string) *aggregator {


### PR DESCRIPTION
# Changes

Bubble up the error instead of logging and ignoring it.

# Why Are Changes Being Made

The following section will log the error as before:

https://github.com/moov-io/achgateway/blob/4533b6fe2a0c802ceebc6ba7535ea0282a804b3f/internal/pipeline/file_receiver.go#L83-L88

Such a situation where somebody could publish a message with the appropriate type should be considered an error.

----

Side note, we encountered an issue where messages weren't acked so the Kafka offset was never moved.
I think that you should ack the message even when there was an error otherwise you will be queueing the system forever.

https://github.com/moov-io/achgateway/blob/4533b6fe2a0c802ceebc6ba7535ea0282a804b3f/internal/pipeline/file_receiver.go#L211

https://github.com/moov-io/achgateway/blob/4533b6fe2a0c802ceebc6ba7535ea0282a804b3f/internal/pipeline/file_receiver.go#L220

https://github.com/moov-io/achgateway/blob/4533b6fe2a0c802ceebc6ba7535ea0282a804b3f/internal/pipeline/file_receiver.go#L228
