### PR TITLE
fix: always ack message

### DIFF
--- a/internal/pipeline/file_receiver.go
+++ b/internal/pipeline/file_receiver.go
@@ -186,6 +186,7 @@ func contains(err error, options ...string) bool {
 }
 
 func (fr *FileReceiver) processMessage(msg *pubsub.Message) error {
+	msg.Ack()
 	data := msg.Body
 	var err error
 
@@ -208,7 +209,6 @@ func (fr *FileReceiver) processMessage(msg *pubsub.Message) error {
 		if err != nil {
 			return err
 		}
-		msg.Ack()
 		return nil
 
 	case *models.QueueACHFile:
@@ -217,7 +217,6 @@ func (fr *FileReceiver) processMessage(msg *pubsub.Message) error {
 		if err != nil {
 			return err
 		}
-		msg.Ack()
 		return nil
 
 	case *models.CancelACHFile:
@@ -225,7 +224,6 @@ func (fr *FileReceiver) processMessage(msg *pubsub.Message) error {
 		if err != nil {
 			return err
 		}
-		msg.Ack()
 		return nil
 	}
 


### PR DESCRIPTION
# Changes

Always `ack` message to move the consumer offset forward.

# Why Are Changes Being Made

**Please validate my assumption** If you must `ack` the message to move the consumer offset regardless of a failure, you can potentially queue the system forever when a loss is expected.

The failures are being logged today, so it should be good from that end.

The final solution would be to move the message into A DLQ (Dead-Letter Queue) in the case of a failure.
