### PR TITLE
pipeline: log and ack unhandled messages instead of getting stuck

### DIFF
--- a/docs/ops/file-options.md
+++ b/docs/ops/file-options.md
@@ -15,3 +15,28 @@ When submitting files to ACHGateway there may be requirements which break Nacha'
 Using the Go package in [achgateway's `models` package](https://pkg.go.dev/github.com/moov-io/achgateway/pkg/models) each event has a method to set `ValidateOpts` on the file. This will be carried through the File for use during merge and upload. Submissions should contain the same `ValidateOpts` to ensure the merged files have the correct overrides.
 
 `func (Event) SetValidation(opts *ach.ValidateOpts)`
+
+#### Errors
+
+If you encounter the following errors you should verify that events sent to ACHGateway are wrapped properly. Try verifying the output of wrapping `pkg/models.Event`'s `MarshalJSON` around your specific events.
+
+```
+nil pubsub message
+```
+```
+unhandled message
+```
+
+Example:
+```
+{
+    "type": "QueueACHFile",
+    "event": {
+        "fileID": "uuid",
+        "shardKey": "uuid",
+        "file": {
+            ...
+        }
+    }
+}
+```

--- a/internal/pipeline/file_receiver.go
+++ b/internal/pipeline/file_receiver.go
@@ -20,6 +20,7 @@ package pipeline
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/moov-io/achgateway/internal/incoming"
@@ -229,8 +230,7 @@ func (fr *FileReceiver) processMessage(msg *pubsub.Message) error {
 		return nil
 	}
 
-	fr.logger.Error().LogErrorf("unexpected %T event", event.Event)
-	return nil
+	return fmt.Errorf("unexpected %T event", event.Event)
 }
 
 func (fr *FileReceiver) getAggregator(shardKey string) *aggregator {

--- a/internal/pipeline/file_receiver.go
+++ b/internal/pipeline/file_receiver.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/Shopify/sarama"
 	"github.com/moov-io/achgateway/internal/incoming"
 	"github.com/moov-io/achgateway/internal/shards"
 	"github.com/moov-io/achgateway/pkg/compliance"
@@ -30,6 +29,7 @@ import (
 	"github.com/moov-io/base/admin"
 	"github.com/moov-io/base/log"
 
+	"github.com/Shopify/sarama"
 	"gocloud.dev/pubsub"
 )
 

--- a/internal/pipeline/file_receiver.go
+++ b/internal/pipeline/file_receiver.go
@@ -187,6 +187,7 @@ func contains(err error, options ...string) bool {
 }
 
 func (fr *FileReceiver) processMessage(msg *pubsub.Message) error {
+	msg.Ack()
 	data := msg.Body
 	var err error
 
@@ -209,7 +210,6 @@ func (fr *FileReceiver) processMessage(msg *pubsub.Message) error {
 		if err != nil {
 			return err
 		}
-		msg.Ack()
 		return nil
 
 	case *models.QueueACHFile:
@@ -218,7 +218,6 @@ func (fr *FileReceiver) processMessage(msg *pubsub.Message) error {
 		if err != nil {
 			return err
 		}
-		msg.Ack()
 		return nil
 
 	case *models.CancelACHFile:
@@ -226,7 +225,6 @@ func (fr *FileReceiver) processMessage(msg *pubsub.Message) error {
 		if err != nil {
 			return err
 		}
-		msg.Ack()
 		return nil
 	}
 

--- a/pkg/models/events.go
+++ b/pkg/models/events.go
@@ -28,6 +28,8 @@ import (
 	"github.com/moov-io/achgateway/internal/incoming"
 )
 
+// Event is a wrapper for all events sent to or received from ACHGateway.
+// It's used to determine the underlying event type.
 type Event struct {
 	Event interface{} `json:"event"`
 	Type  string      `json:"type"`
@@ -103,6 +105,8 @@ type Batch struct {
 // from the ODFI. This is also called a "Notification of Change" (NOC).
 //
 // File.ID will be set to a hash of the Nacha contents.
+//
+// See the Event struct for wrapping steps.
 type CorrectionFile struct {
 	Filename    string    `json:"filename"`
 	File        *ach.File `json:"file"`
@@ -120,6 +124,8 @@ func (evt *CorrectionFile) SetValidation(opts *ach.ValidateOpts) {
 // signifying entries to process (e.g. another FI is debiting your account).
 //
 // File.ID will be set to a hash of the Nacha contents.
+//
+// See the Event struct for wrapping steps.
 type IncomingFile struct {
 	Filename string    `json:"filename"`
 	File     *ach.File `json:"file"`
@@ -136,6 +142,8 @@ func (evt *IncomingFile) SetValidation(opts *ach.ValidateOpts) {
 // This type of file is used to validate accounts exist and are usable for ACH.
 //
 // File.ID will be set to a hash of the Nacha contents.
+//
+// See the Event struct for wrapping steps.
 type PrenoteFile struct {
 	Filename string    `json:"filename"`
 	File     *ach.File `json:"file"`
@@ -152,6 +160,8 @@ func (evt *PrenoteFile) SetValidation(opts *ach.ValidateOpts) {
 // ReconciliationFile is a file whose entries match entries initiated with the ODFI.
 //
 // File.ID will be set to a hash of the Nacha contents.
+//
+// See the Event struct for wrapping steps.
 type ReconciliationFile struct {
 	Filename        string    `json:"filename"`
 	File            *ach.File `json:"file"`
@@ -169,6 +179,8 @@ func (evt *ReconciliationFile) SetValidation(opts *ach.ValidateOpts) {
 // from the ODFI. This is also called a "return".
 //
 // File.ID will be set to a hash of the Nacha contents.
+//
+// See the Event struct for wrapping steps.
 type ReturnFile struct {
 	Filename string    `json:"filename"`
 	File     *ach.File `json:"file"`
@@ -184,6 +196,8 @@ func (evt *ReturnFile) SetValidation(opts *ach.ValidateOpts) {
 
 // QueueACHFile is an event that achgateway receives to enqueue an ACH file for upload to the
 // ODFI at a later cutoff time.
+//
+// See the Event struct for wrapping steps.
 type QueueACHFile incoming.ACHFile
 
 func (evt *QueueACHFile) SetValidation(opts *ach.ValidateOpts) {
@@ -194,6 +208,8 @@ func (evt *QueueACHFile) SetValidation(opts *ach.ValidateOpts) {
 }
 
 // CancelACHFile is an event that achgateway receives to cancel uploading a file to the ODFI.
+//
+// See the Event struct for wrapping steps.
 type CancelACHFile incoming.CancelACHFile
 
 // FileUploaded is an event sent after a queued file has been uploaded to the ODFI.


### PR DESCRIPTION
This is a combination of https://github.com/moov-io/achgateway/pull/137 and https://github.com/moov-io/achgateway/pull/138 to better handle/log unhandled messages. We should make it more obvious what the error is with handling the event. 

