### PR TITLE
shards: simplify config file mapping syntax

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -227,13 +227,10 @@ ACHGateway:
           Retry:
             Interval: <duration>
             MaxRetries: <integer>
-    Mappings:
-      <label>:
-        # Could be random value (UUID, fixed string)
-        ShardKey: <string>
-        # Maps to Sharding.Shards[_].name
-        ShardName: <string>
     [ Default: <string> ]
+    Mappings:
+      - ShardKey: <string>  # Can be random value (UUID, fixed string)
+        ShardName: <string> # Maps to Sharding.Shards[_].name
 ```
 
 ### Upload Agents

--- a/internal/pipeline/file_receiver_test.go
+++ b/internal/pipeline/file_receiver_test.go
@@ -36,7 +36,7 @@ func TestFileReceiver(t *testing.T) {
 func testFileReceiver(t *testing.T) *FileReceiver {
 	logger := log.NewNopLogger()
 	shard := "testing"
-	shardRepo := shards.NewMockRepository()
+	shardRepo := shards.NewInMemoryRepository()
 	shardAggregators := make(map[string]*aggregator)
 	_, httpFiles := streamtest.InmemStream(t)
 	_, streamFiles := streamtest.InmemStream(t)

--- a/internal/service/model_sharding.go
+++ b/internal/service/model_sharding.go
@@ -40,7 +40,7 @@ var (
 
 type Sharding struct {
 	Shards   []Shard
-	Mappings map[string]ShardMapping
+	Mappings []ShardMapping
 	Default  string
 }
 

--- a/internal/shards/repository.go
+++ b/internal/shards/repository.go
@@ -20,8 +20,10 @@ package shards
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/moov-io/achgateway/internal/service"
 	"github.com/moov-io/base/database"
+
 	"github.com/pkg/errors"
 )
 
@@ -31,7 +33,7 @@ type Repository interface {
 	Add(create service.ShardMapping, run database.RunInTx) error
 }
 
-func NewRepository(db *sql.DB, static map[string]service.ShardMapping) Repository {
+func NewRepository(db *sql.DB, static []service.ShardMapping) Repository {
 	if db == nil {
 		return &InMemoryRepository{Shards: static}
 	}

--- a/internal/shards/scope_shard_mapping_test.go
+++ b/internal/shards/scope_shard_mapping_test.go
@@ -5,16 +5,18 @@ package shards_test
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/gorilla/mux"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/moov-io/achgateway/internal"
 	"github.com/moov-io/achgateway/internal/service"
 	"github.com/moov-io/achgateway/internal/shards"
 	"github.com/moov-io/base/log"
 	"github.com/moov-io/base/stime"
+
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 type TestEnvironment struct {
@@ -65,7 +67,7 @@ func ShardMappingTestSetup(t *testing.T) ShardMappingTestScope {
 	router := mux.NewRouter()
 	testEnv := NewTestEnvironment(t, router)
 
-	repository := shards.NewMockRepository()
+	repository := shards.NewInMemoryRepository()
 	service, err := shards.NewShardMappingService(testEnv.TimeService, testEnv.Logger, repository)
 	if err != nil {
 		t.Error(err)

--- a/internal/test/upload_test.go
+++ b/internal/test/upload_test.go
@@ -148,7 +148,7 @@ func TestUploads(t *testing.T) {
 	consulClient, err := consul.NewConsulClient(logger, cfg.Consul)
 	require.NoError(t, err)
 
-	shardRepo := shards.NewMockRepository()
+	shardRepo := shards.NewInMemoryRepository()
 	shardKeys := setupShards(t, shardRepo)
 
 	httpPub, httpSub := streamtest.InmemStream(t)
@@ -311,9 +311,9 @@ func setupShards(t *testing.T, repo *shards.InMemoryRepository) []string {
 	for i := 0; i < 10; i++ {
 		shardKey := base.ID()
 		if i%2 == 0 {
-			repo.Shards[shardKey] = service.ShardMapping{ShardKey: shardKey, ShardName: "prod"}
+			repo.Add(service.ShardMapping{ShardKey: shardKey, ShardName: "prod"}, database.NopInTx)
 		} else {
-			repo.Shards[shardKey] = service.ShardMapping{ShardKey: shardKey, ShardName: "beta"}
+			repo.Add(service.ShardMapping{ShardKey: shardKey, ShardName: "beta"}, database.NopInTx)
 		}
 		out = append(out, shardKey)
 	}


### PR DESCRIPTION
Rather than https://github.com/moov-io/achgateway/pull/152 what if we simplified the config syntax to avoid this bug all together? 