### PR TITLE
Support nested inbound directory structures

### DIFF
--- a/examples/getting-started/config.yml
+++ b/examples/getting-started/config.yml
@@ -66,7 +66,7 @@ ACHGateway:
           username: "admin"
           password: "123456"
         paths:
-          inbound: "/returned/"
+          inbound: "/inbound/"
           outbound: "/outbound/"
           reconciliation: "/reconciliation/"
           return: "/returned/"

--- a/internal/incoming/odfi/processor.go
+++ b/internal/incoming/odfi/processor.go
@@ -124,11 +124,16 @@ func processDir(dir string, auditSaver *AuditSaver, fileProcessors Processors) e
 	}
 
 	var el base.ErrorList
-	for i := range infos {
-		where := filepath.Join(dir, infos[i].Name())
-
-		if err := processFile(where, auditSaver, fileProcessors); err != nil {
-			el.Add(err)
+	for _, info := range infos {
+		where := filepath.Join(dir, info.Name())
+		if info.IsDir() {
+			if err := processDir(where, auditSaver, fileProcessors); err != nil {
+				el.Add(err)
+			}
+		} else {
+			if err := processFile(where, auditSaver, fileProcessors); err != nil {
+				el.Add(err)
+			}
 		}
 	}
 

--- a/internal/incoming/odfi/scheduler.go
+++ b/internal/incoming/odfi/scheduler.go
@@ -174,7 +174,7 @@ func (s *PeriodicScheduler) tick(shard *service.Shard) error {
 	}
 
 	// Run each processor over the files
-	if err := ProcessFiles(dl, auditSaver, s.processors); err != nil {
+	if err := ProcessFiles(dl, auditSaver, s.processors, agent); err != nil {
 		return fmt.Errorf("ERROR: processing files: %v", err)
 	}
 


### PR DESCRIPTION
# Changes
Adds in the ability to have a nested directory as the source of incoming files.

# Why Are Changes Being Made
Currently when processing an `inbound` folder that is a nested directory (ex: ```"inbound": "/client_directory/with/subpath"```, the processing of the files fails due to `processFile` being called with a directory instead of a specific file. This is not a fair assumption if the `InboundPath()`, `ReconciliationPath()`, etc. have any "depth" to them.  

[In other places](https://github.com/moov-io/achgateway/blob/8331bfc2686c9cd858bb75714d003b91a1dda208/internal/incoming/odfi/cleanup.go#L34) we make use explicitly of the agent's path information to determine what folders/files to operate on.  Following a similar pattern here. 

NOTE: The way that the audit folder path is constructed in `processFile` currently does *not* show the full/nested path but rather just the "last" directory in this hierarchy.  If the full path would be preferred (debatable) can also work on making some of those changes.