### PR TITLE
feat: support gzip compression with Transforms

### DIFF
--- a/pkg/models/model_transform.go
+++ b/pkg/models/model_transform.go
@@ -29,7 +29,8 @@ type TransformConfig struct {
 }
 
 type EncodingConfig struct {
-	Base64 bool
+	Base64   bool
+	Compress bool
 }
 
 type EncryptionConfig struct {


### PR DESCRIPTION
Often File events need to be compressed in Kafka messages. The defaults in Kafka are fairly low and real-world ACH files can easily exceed them. Let's offer a basic compression boolean for folks to leverage. 

Gzip has the best support in Go. bzip2 only supports reads. 