### PR TITLE
test: verify we reconnect from flakey subscriptions

### DIFF
--- a/internal/environment.go
+++ b/internal/environment.go
@@ -163,7 +163,7 @@ func NewEnvironment(env *Environment) (*Environment, error) {
 	}
 
 	// file pipeline
-	httpSub, err := stream.Subscription(env.Logger, inmemConfig)
+	httpSub, err := stream.OpenSubscription(env.Logger, inmemConfig)
 	if err != nil {
 		return env, fmt.Errorf("unable to create http files subscription: %v", err)
 	}

--- a/internal/incoming/stream/publisher_test.go
+++ b/internal/incoming/stream/publisher_test.go
@@ -29,7 +29,7 @@ func TestStream(t *testing.T) {
 	require.NoError(t, err)
 	defer topic.Shutdown(ctx)
 
-	sub, err := Subscription(log.NewNopLogger(), cfg)
+	sub, err := OpenSubscription(log.NewNopLogger(), cfg)
 	require.NoError(t, err)
 	defer sub.Shutdown(ctx)
 
@@ -53,7 +53,7 @@ func send(ctx context.Context, t *pubsub.Topic, body string) *pubsub.Message {
 	return msg
 }
 
-func receive(ctx context.Context, t *pubsub.Subscription) (string, error) {
+func receive(ctx context.Context, t Subscription) (string, error) {
 	msg, err := t.Receive(ctx)
 	if err != nil {
 		return "", err

--- a/internal/incoming/stream/streamtest/streamtest.go
+++ b/internal/incoming/stream/streamtest/streamtest.go
@@ -55,11 +55,9 @@ func InmemStream(t *testing.T) (*pubsub.Topic, stream.Subscription) {
 
 type FailedSubscription struct {
 	Err error
-	N   int
 }
 
 func (s *FailedSubscription) Receive(ctx context.Context) (*pubsub.Message, error) {
-	s.N++
 	return nil, s.Err
 }
 

--- a/internal/incoming/stream/streamtest/streamtest.go
+++ b/internal/incoming/stream/streamtest/streamtest.go
@@ -52,3 +52,21 @@ func InmemStream(t *testing.T) (*pubsub.Topic, stream.Subscription) {
 
 	return topic, sub
 }
+
+type FailedSubscription struct {
+	Err error
+	N   int
+}
+
+func (s *FailedSubscription) Receive(ctx context.Context) (*pubsub.Message, error) {
+	s.N++
+	return nil, s.Err
+}
+
+func (s *FailedSubscription) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+func FailingSubscription(err error) *FailedSubscription {
+	return &FailedSubscription{Err: err}
+}

--- a/internal/incoming/stream/streamtest/streamtest.go
+++ b/internal/incoming/stream/streamtest/streamtest.go
@@ -32,7 +32,7 @@ import (
 	"gocloud.dev/pubsub"
 )
 
-func InmemStream(t *testing.T) (*pubsub.Topic, *pubsub.Subscription) {
+func InmemStream(t *testing.T) (*pubsub.Topic, stream.Subscription) {
 	t.Helper()
 
 	n, _ := rand.Int(rand.Reader, big.NewInt(10000))
@@ -46,7 +46,7 @@ func InmemStream(t *testing.T) (*pubsub.Topic, *pubsub.Subscription) {
 	topic, err := stream.Topic(log.NewNopLogger(), conf)
 	require.NoError(t, err)
 
-	sub, err := stream.Subscription(log.NewNopLogger(), conf)
+	sub, err := stream.OpenSubscription(log.NewNopLogger(), conf)
 	require.NoError(t, err)
 	t.Cleanup(func() { sub.Shutdown(context.Background()) })
 

--- a/internal/incoming/stream/subscription.go
+++ b/internal/incoming/stream/subscription.go
@@ -27,7 +27,12 @@ import (
 	"gocloud.dev/pubsub"
 )
 
-func Subscription(logger log.Logger, cfg *service.Config) (*pubsub.Subscription, error) {
+type Subscription interface {
+	Receive(ctx context.Context) (*pubsub.Message, error)
+	Shutdown(ctx context.Context) error
+}
+
+func OpenSubscription(logger log.Logger, cfg *service.Config) (Subscription, error) {
 	if cfg.Inbound.InMem != nil {
 		sub, err := pubsub.OpenSubscription(context.Background(), cfg.Inbound.InMem.URL)
 		if err != nil {

--- a/internal/pipeline/file_receiver.go
+++ b/internal/pipeline/file_receiver.go
@@ -93,6 +93,10 @@ func (fr *FileReceiver) reconnect() error {
 	return nil
 }
 
+func (fr *FileReceiver) ReplaceStreamFiles(sub stream.Subscription) {
+	fr.streamFiles = sub
+}
+
 func (fr *FileReceiver) Start(ctx context.Context) {
 	for {
 		// Create a context that will be shutdown by its parent or after a read iteration
@@ -183,7 +187,7 @@ func (fr *FileReceiver) handleMessage(ctx context.Context, sub stream.Subscripti
 					return
 				}
 				// Bubble up some errors to alerting
-				if contains(err, "connect: ", "pubsub", "EOF") {
+				if contains(err, "connect: ", "write:", "broken pipe", "pubsub", "EOF") {
 					out <- err
 				}
 				fr.logger.LogErrorf("ERROR receiving message: %v", err)

--- a/internal/pipeline/file_receiver.go
+++ b/internal/pipeline/file_receiver.go
@@ -94,6 +94,10 @@ func (fr *FileReceiver) reconnect() error {
 }
 
 func (fr *FileReceiver) ReplaceStreamFiles(sub stream.Subscription) {
+	// Close an existing stream subscription
+	if fr.streamFiles != nil {
+		fr.streamFiles.Shutdown(context.Background())
+	}
 	fr.streamFiles = sub
 }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -23,12 +23,11 @@ import (
 
 	"github.com/moov-io/achgateway/internal/consul"
 	"github.com/moov-io/achgateway/internal/events"
+	"github.com/moov-io/achgateway/internal/incoming/stream"
 	"github.com/moov-io/achgateway/internal/service"
 	"github.com/moov-io/achgateway/internal/shards"
 	"github.com/moov-io/achgateway/pkg/models"
 	"github.com/moov-io/base/log"
-
-	"gocloud.dev/pubsub"
 )
 
 func Start(
@@ -37,7 +36,7 @@ func Start(
 	cfg *service.Config,
 	consul *consul.Client,
 	shardRepository shards.Repository,
-	httpFiles *pubsub.Subscription,
+	httpFiles stream.Subscription,
 ) (*FileReceiver, error) {
 
 	eventEmitter, err := events.NewEmitter(logger, cfg.Events)


### PR DESCRIPTION
We've been seeing this issue of infinite logging when the stream subscription fails. After https://github.com/moov-io/achgateway/pull/160 added reconnect logic we should verify that cycle is working. 