### PR TITLE
pipeline: require shardNames when manually triggering cutoff windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ achgateway_1  | ts=2021-06-18T23:38:16Z msg="finished handling ACHFile=f4" level
 
 Initiate cutoff time processing (aka upload to your ODFI):
 ```
-$ curl -XPUT "http://localhost:9494/trigger-cutoff"
+$ curl -XPUT "http://localhost:9494/trigger-cutoff" --data '{"shardNames":["foo"]}'
 achgateway_1  | ts=2021-06-18T23:38:20Z msg="starting manual cutoff window processing" level=info app=achgateway version=v0.4.1
 achgateway_1  | ts=2021-06-18T23:38:20Z msg="processing mergable directory foo" level=info app=achgateway version=v0.4.1 shardKey=foo
 achgateway_1  | ts=2021-06-18T23:38:20Z msg="found *upload.FTPTransferAgent agent" version=v0.4.1 shardKey=foo level=info app=achgateway

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -39,7 +39,7 @@ achgateway_1  | ts=2021-06-18T23:38:16Z msg="finished handling ACHFile=f4" level
 
 Initiate cutoff time processing (aka upload to your ODFI):
 ```
-$ curl -XPUT "http://localhost:9494/trigger-cutoff"
+$ curl -XPUT "http://localhost:9494/trigger-cutoff" --data '{"shardNames":["foo"]}'
 achgateway_1  | ts=2021-06-18T23:38:20Z msg="starting manual cutoff window processing" level=info app=achgateway version=v0.4.1
 achgateway_1  | ts=2021-06-18T23:38:20Z msg="processing mergable directory foo" level=info app=achgateway version=v0.4.1 shardKey=foo
 achgateway_1  | ts=2021-06-18T23:38:20Z msg="found *upload.FTPTransferAgent agent" version=v0.4.1 shardKey=foo level=info app=achgateway

--- a/internal/pipeline/manual_cutoff_times_test.go
+++ b/internal/pipeline/manual_cutoff_times_test.go
@@ -18,6 +18,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -36,7 +37,7 @@ func TestManualCutoffs_filter(t *testing.T) {
 	var reqNames []string
 	cfgName := "testing"
 
-	require.True(t, exists(reqNames, cfgName))
+	require.False(t, exists(reqNames, cfgName))
 
 	reqNames = append(reqNames, "live-odfi")
 	require.False(t, exists(reqNames, cfgName))
@@ -51,8 +52,11 @@ func TestFileReceiver__ManualCutoff(t *testing.T) {
 	router := mux.NewRouter()
 	router.Path("/trigger-cutoff").HandlerFunc(fr.triggerManualCutoff())
 
+	var buf bytes.Buffer
+	buf.WriteString(`{"shardNames":["testing"]}`)
+
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("PUT", "/trigger-cutoff", nil)
+	req := httptest.NewRequest("PUT", "/trigger-cutoff", &buf)
 	router.ServeHTTP(w, req)
 
 	wg.Wait()
@@ -74,8 +78,11 @@ func TestFileReceiver__ManualCutoffErr(t *testing.T) {
 	router := mux.NewRouter()
 	router.Path("/trigger-cutoff").HandlerFunc(fr.triggerManualCutoff())
 
+	var buf bytes.Buffer
+	buf.WriteString(`{"shardNames":["testing"]}`)
+
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("PUT", "/trigger-cutoff", nil)
+	req := httptest.NewRequest("PUT", "/trigger-cutoff", &buf)
 	router.ServeHTTP(w, req)
 
 	wg.Wait()

--- a/internal/test/upload_test.go
+++ b/internal/test/upload_test.go
@@ -192,7 +192,10 @@ func TestUploads(t *testing.T) {
 	require.Greater(t, canceledEntries, 0)
 	time.Sleep(5 * time.Second)
 
-	req, _ := http.NewRequest("PUT", "http://"+adminServer.BindAddr()+"/trigger-cutoff", nil)
+	var buf bytes.Buffer
+	buf.WriteString(`{"shardNames":["prod", "beta"]}`)
+
+	req, _ := http.NewRequest("PUT", "http://"+adminServer.BindAddr()+"/trigger-cutoff", &buf)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -301,7 +301,7 @@ paths:
       requestBody:
         description: |
           List of shards to trigger cutoff processing for. If no shards are specified then all configured shards will be processed.
-        required: false
+        required: true
         content:
           application/json:
             schema:
@@ -415,13 +415,15 @@ components:
 
     TriggerRequest:
       properties:
-        ShardNames:
+        shardNames:
           type: array
           items:
             type: string
           example:
             - "SD-live"
             - "ND-live"
+      required:
+        - shardNames
 
     TriggerResponse:
       properties:


### PR DESCRIPTION
We've ran into a few problems internally when accidentally not including shardNames. Either by accident or typo it is too easy to trigger all shards, which is rarely desired. It seems safer to require at least one shard name rather than default to all processing all shards. 