### PR TITLE
Include network errors in upload test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	gocloud.dev/pubsub/kafkapubsub v0.26.0
 	goftp.io/server v0.4.1
 	golang.org/x/crypto v0.7.0
+	golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0
 	golang.org/x/text v0.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1656,6 +1656,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 h1:pVgRXcIictcr+lBQIFeiwuwtDIs4eL21OuM9nyAADmo=
+golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/internal/test/upload_test.go
+++ b/internal/test/upload_test.go
@@ -70,7 +70,7 @@ var (
 		},
 		Inbound: service.Inbound{
 			InMem: &service.InMemory{
-				URL: "mem://upload-test",
+				URL: "mem://upload-test?ackdeadline=1s",
 			},
 		},
 		Sharding: service.Sharding{

--- a/internal/test/upload_test.go
+++ b/internal/test/upload_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -182,6 +183,7 @@ func TestUploads(t *testing.T) {
 	// Upload our files
 	createdEntries := 0
 	canceledEntries := 0
+	erroredSubscriptions := 0
 	for i := 0; i < 1000; i++ {
 		shardKey := shardKeys[i%10]
 		fileID := base.ID()
@@ -191,6 +193,13 @@ func TestUploads(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Code)
 
 		canceledEntries += maybeCancelFile(t, r, shardKey, fileID, file)
+
+		// Force the subscription to fail sometimes
+		if err := causeSubscriptionFailure(t); err != nil {
+			flakeySub := streamtest.FailingSubscription(err)
+			fileReceiver.ReplaceStreamFiles(flakeySub)
+			erroredSubscriptions += 1
+		}
 	}
 
 	t.Logf("created %d entries and canceled %d entries", createdEntries, canceledEntries)
@@ -215,7 +224,7 @@ func TestUploads(t *testing.T) {
 
 	expected := createdEntries - canceledEntries
 	found := countAllEntries(createdFiles)
-	t.Logf("found %d entries of %d expected (%d canceled)", found, expected, canceledEntries)
+	t.Logf("found %d entries of %d expected (%d canceled) (%d errored)", found, expected, canceledEntries, erroredSubscriptions)
 	require.Equal(t, found, expected)
 }
 
@@ -380,4 +389,21 @@ func cancelFile(t *testing.T, r *mux.Router, shardKey, fileID string) {
 	r.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
+}
+
+var subscriptionFailures = []error{
+	io.EOF,
+	errors.New("write: broken pipe"),
+	errors.New("contains: pubsub error"),
+}
+
+func causeSubscriptionFailure(t *testing.T) error {
+	t.Helper()
+
+	n := rand.Int63n(100) //nolint:gosec
+	if n%25 == 0 {
+		idx := (len(subscriptionFailures) - 1) % (int(n) + 1)
+		return subscriptionFailures[idx]
+	}
+	return nil
 }


### PR DESCRIPTION
We've been working to harden this reconnect logic due to flakey kafka brokers. This is another hardening change. 