### PR TITLE
incoming/odfi: allow configuration of ValidateOpts

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -141,6 +141,8 @@ ACHGateway:
           [ Enabled: <boolean> | default = false]
           # Partial filename to match on. Example: "RET_"
           [ PathMatcher: <string> | default = "" ]
+        Validation:
+          # See moov-io/ach's ValidateOpts for the full list of options
       Publishing:
         Kafka:
           Brokers:

--- a/internal/incoming/odfi/processor_test.go
+++ b/internal/incoming/odfi/processor_test.go
@@ -46,12 +46,13 @@ func TestProcessor(t *testing.T) {
 		storage:  &audittrail.MockStorage{},
 		hostname: "ftp.foo.com",
 	}
+	var validation ach.ValidateOpts
 	alerters, _ := alerting.NewAlerters(service.ErrorAlerting{})
 
 	// By reading a file without ACH FileHeaders we still want to try and process
 	// Batches inside of it if any are found, so reading this kind of file shouldn't
 	// return an error from reading the file.
-	err = processDir(dir, alerters, auditSaver, processors)
+	err = processDir(dir, alerters, auditSaver, validation, processors)
 	require.NoError(t, err)
 
 	require.NotNil(t, proc.HandledFile)
@@ -60,7 +61,7 @@ func TestProcessor(t *testing.T) {
 
 	// Real world file
 	path := filepath.Join("..", "..", "..", "testdata", "HMBRAD_ACHEXPORT_1001_08_19_2022_09_10")
-	err = processFile(path, alerters, auditSaver, processors)
+	err = processFile(path, alerters, auditSaver, validation, processors)
 	if err != nil {
 		require.ErrorContains(t, err, "record:FileHeader *ach.FieldError FileCreationDate  is a mandatory field")
 	}

--- a/internal/incoming/odfi/scheduler.go
+++ b/internal/incoming/odfi/scheduler.go
@@ -174,7 +174,7 @@ func (s *PeriodicScheduler) tick(shard *service.Shard) error {
 	}
 
 	// Run each processor over the files
-	if err := ProcessFiles(dl, s.alerters, auditSaver, s.processors, agent); err != nil {
+	if err := ProcessFiles(dl, s.alerters, auditSaver, s.odfi.Processors.Validation, s.processors, agent); err != nil {
 		return fmt.Errorf("ERROR: processing files: %v", err)
 	}
 

--- a/internal/service/model_inbound.go
+++ b/internal/service/model_inbound.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/moov-io/ach"
 	"github.com/moov-io/achgateway/pkg/models"
 )
 
@@ -137,6 +138,8 @@ type ODFIProcessors struct {
 	Reconciliation ODFIReconciliation
 	Prenotes       ODFIPrenotes
 	Returns        ODFIReturns
+
+	Validation ach.ValidateOpts
 }
 
 func (cfg ODFIProcessors) Validate() error {


### PR DESCRIPTION
Rather than hardcoding a few options let's allow the full set of configuration knobs.


