### PR TITLE
Correcting Error Messaging on Publish

### DIFF
--- a/internal/incoming/odfi/processor.go
+++ b/internal/incoming/odfi/processor.go
@@ -164,7 +164,7 @@ func processFile(path string, alerters alerting.Alerters, auditSaver *AuditSaver
 	})
 	if err != nil {
 		alertErr := alerters.AlertError(err)
-		if err != nil {
+		if alertErr != nil {
 			return fmt.Errorf("problem alerting on error: %w", alertErr)
 		}
 		return fmt.Errorf("processing %s error: %v", path, err)


### PR DESCRIPTION
# Changes
When an error occurs while attemping to send a message to a processor the error message is currently unclear due to an interpolation issue.

```
error with odfi periodic processing: ERROR: processing files: processDir /storage/download3767115277/FromACHTH/ACHFiles: problem alerting on error: **%!w(<nil>)
```

# Why Are Changes Being Made
Error message currently is not accurately rendering due to `alertErr` being nil.