### PR TITLE
Error handling fixes

### DIFF
--- a/internal/pipeline/events_api_test.go
+++ b/internal/pipeline/events_api_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/moov-io/ach"
 	"github.com/moov-io/achgateway/internal/admintest"
 	"github.com/moov-io/achgateway/internal/events"
+	"github.com/moov-io/achgateway/internal/service"
 	"github.com/moov-io/achgateway/pkg/compliance"
 	"github.com/moov-io/achgateway/pkg/models"
 	"github.com/moov-io/base"
@@ -40,7 +41,7 @@ import (
 func TestEventsAPI_FileUploaded(t *testing.T) {
 	adminServer := admintest.Server(t)
 
-	fr := testFileReceiver(t)
+	fr := testFileReceiver(t, func(conf *service.Config) {})
 	fr.RegisterAdminRoutes(adminServer)
 
 	// Write a file that's produced
@@ -125,7 +126,7 @@ func TestEventsAPI_FileUploaded(t *testing.T) {
 func TestEventsAPI_FileUploadedErrors(t *testing.T) {
 	adminServer := admintest.Server(t)
 
-	fr := testFileReceiver(t)
+	fr := testFileReceiver(t, func(conf *service.Config) {})
 	fr.RegisterAdminRoutes(adminServer)
 
 	t.Run("Call /file-uploaded on a shard that doesn't exist", func(t *testing.T) {

--- a/internal/pipeline/file_receiver.go
+++ b/internal/pipeline/file_receiver.go
@@ -201,7 +201,7 @@ func (fr *FileReceiver) handleMessage(ctx context.Context, sub stream.Subscripti
 		go func() {
 			msg, err := sub.Receive(ctx)
 			if err != nil {
-				if err == context.Canceled {
+				if errors.Is(err, context.Canceled) {
 					return
 				}
 				if strings.Contains(err.Error(), "Subscription has been Shutdown") {
@@ -268,7 +268,8 @@ func (fr *FileReceiver) processMessage(msg *pubsub.Message) error {
 	// Optionally decode and decrypt message
 	data, err = compliance.Reveal(fr.transformConfig, data)
 	if err != nil {
-		return logger.LogErrorf("unable to reveal event: %v", err).Err()
+		logger.LogErrorf("unable to reveal event: %v", err)
+		data = msg.Body
 	}
 
 	event, readErr := models.Read(data)

--- a/internal/pipeline/file_receiver.go
+++ b/internal/pipeline/file_receiver.go
@@ -274,7 +274,7 @@ func (fr *FileReceiver) processMessage(msg *pubsub.Message) error {
 
 	event, readErr := models.Read(data)
 	if readErr != nil {
-		logger.LogErrorf("unable to read %s event: %v", event.Type, readErr)
+		return logger.LogErrorf("unable to read %s event: %v", event.Type, readErr).Err()
 	}
 
 	var file *incoming.ACHFile

--- a/internal/pipeline/file_receiver.go
+++ b/internal/pipeline/file_receiver.go
@@ -274,7 +274,7 @@ func (fr *FileReceiver) processMessage(msg *pubsub.Message) error {
 
 	event, readErr := models.Read(data)
 	if readErr != nil {
-		return logger.LogErrorf("unable to read %s event: %v", event.Type, readErr).Err()
+		logger.LogErrorf("unable to read %s event: %v", event.Type, readErr)
 	}
 
 	var file *incoming.ACHFile

--- a/internal/pipeline/file_receiver_test.go
+++ b/internal/pipeline/file_receiver_test.go
@@ -168,12 +168,9 @@ func TestFileReceiver__InvalidQueueFile(t *testing.T) {
 func TestFileReceiver__CancelFile(t *testing.T) {
 	fr := testFileReceiver(t)
 
-	//file, err := ach.ReadFile(filepath.Join("..", "incoming", "odfi", "testdata", "return-no-batch-controls.ach"))
-	//require.ErrorContains(t, err, ach.ErrFileHeader.Error())
-
 	bs, err := compliance.Protect(nil, models.Event{
 		Event: models.CancelACHFile{
-			FileID:   "return-no-batch-controls.ach",
+			FileID:   "return-no-batch-controls",
 			ShardKey: "testing",
 		},
 	})

--- a/internal/pipeline/file_receiver_test.go
+++ b/internal/pipeline/file_receiver_test.go
@@ -182,7 +182,7 @@ func TestFileReceiver__CancelFile(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		file2, err := ach.ReadFile(filepath.Join("mergable", "testing", fmt.Sprintf("%s.ach.cancelled", "return-no-batch-controls.ach")))
+		file2, err := ach.ReadFile(filepath.Join("mergable", "testing", fmt.Sprintf("%s.cancelled", "return-no-batch-controls.ach")))
 		if err != nil {
 			t.Logf("waiting for file to be canceled: %v", err)
 		}

--- a/internal/pipeline/file_receiver_test.go
+++ b/internal/pipeline/file_receiver_test.go
@@ -167,6 +167,8 @@ func TestFileReceiver__InvalidQueueFile(t *testing.T) {
 
 func TestFileReceiver__CancelFile(t *testing.T) {
 	fr := testFileReceiver(t)
+	s, err := storage.New(fr.cfg.Upload.Merging.Storage)
+	require.NoError(t, err)
 
 	bs, err := compliance.Protect(nil, models.Event{
 		Event: models.CancelACHFile{
@@ -182,12 +184,12 @@ func TestFileReceiver__CancelFile(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		file2, err := ach.ReadFile(filepath.Join("mergable", "testing", fmt.Sprintf("%s.cancelled", "return-no-batch-controls.ach")))
+		file2, err := s.Open(filepath.Join("mergable", "testing", fmt.Sprintf("%s.canceled", "return-no-batch-controls.ach")))
 		if err != nil {
 			t.Logf("waiting for file to be canceled: %v", err)
 		}
 		if file2 != nil {
-			t.Logf("file2.ID: %s", file2.ID)
+			t.Logf("file2.Filename: %s", file2.Filename())
 		}
 		return file2 != nil
 	}, 60*time.Second, 500*time.Millisecond)


### PR DESCRIPTION
# Changes

Fix to error handling for events

# Why Are Changes Being Made

Better logging for error handling.
Better support for events written without encryption to be decrypted.

The specific flow used to see this is the `http://localhost:8080/shards/{shardName}/files/{fileID}` endpoint, which produces an unencrypted event to pass internally for achgateway to consume, where the consumer expects the event to be encrypted.