### PR TITLE
fix(repository): correct an issue with shard querying in spanner

### DIFF
--- a/internal/shards/repository.go
+++ b/internal/shards/repository.go
@@ -189,7 +189,12 @@ func (r *spannerRepository) Lookup(shardKey string) (string, error) {
 		return "", err
 	}
 
-	return row.String(), nil
+	var shardName string
+	if err := row.ColumnByName("shard_name", &shardName); err != nil {
+		return "", err
+	}
+
+	return shardName, nil
 }
 
 func (r *spannerRepository) List() ([]service.ShardMapping, error) {


### PR DESCRIPTION
# Changes
Correctly scan shard name from the Spanner DB row returned when querying for a shard name by shard key

# Why Are Changes Being Made
Currently the spanner query for a shard name is returning a string representation of the entire row instead of just the string value of the shard name.