### PR TITLE
add  to marshal interface for SFTP config

### DIFF
--- a/internal/service/model_upload.go
+++ b/internal/service/model_upload.go
@@ -169,6 +169,7 @@ func (cfg *SFTP) MarshalJSON() ([]byte, error) {
 		MaxPacketSize         int
 
 		SkipDirectoryCreation bool
+		SkipChmodAfterUpload  bool
 	}
 	return json.Marshal(Aux{
 		Hostname: cfg.Hostname,
@@ -184,6 +185,7 @@ func (cfg *SFTP) MarshalJSON() ([]byte, error) {
 		MaxPacketSize:         cfg.MaxPacketSize,
 
 		SkipDirectoryCreation: cfg.SkipDirectoryCreation,
+		SkipChmodAfterUpload:  cfg.SkipChmodAfterUpload,
 	})
 }
 


### PR DESCRIPTION
# Changes

Adds new SkipChmodAfterUpload value to the SFTP config's marshal interface implementation.

# Why Are Changes Being Made

To ensure the API response of the config endpoint matches the config in use.
