### PR TITLE
feat: configuration for cutoffs on non-banking days

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -183,6 +183,7 @@ ACHGateway:
           Timezone: <string>
           Windows:
             - <string>
+          [ On: <string> | default = "banking-days" ] # banking-days or all-days
         PreUpload:
           GPG: # Optional
             KeyFile: <string>

--- a/internal/pipeline/aggregate.go
+++ b/internal/pipeline/aggregate.go
@@ -128,13 +128,12 @@ func (xfagg *aggregator) Start(ctx context.Context) {
 		// process automated cutoff time triggering
 		case day := <-xfagg.cutoffs.C:
 			// Run our regular routines
-			if day.IsBankingDay {
+			if day.IsBankingDay || xfagg.shard.Cutoffs.On == "all-days" {
 				if err := xfagg.withEachFile(day.Time); err != nil {
 					err = xfagg.logger.Error().LogErrorf("merging files: %v", err).Err()
 					xfagg.alertOnError(err)
 				}
-			}
-			if day.IsHoliday && !day.IsWeekend {
+			} else if day.IsHoliday && !day.IsWeekend {
 				xfagg.notifyAboutHoliday(day)
 			}
 

--- a/internal/service/model_sharding.go
+++ b/internal/service/model_sharding.go
@@ -107,6 +107,7 @@ func (cfg Shard) Validate() error {
 type Cutoffs struct {
 	Timezone string
 	Windows  []string
+	On       string
 }
 
 func (cfg Cutoffs) Location() *time.Location {


### PR DESCRIPTION
# Changes
Adds a configuration option of `on` to `cutoffs` which instructs the gateway on which days to run the cutoffs. Default behavior is the existing behavior of `banking-days` only. Any option besides `all-days` will execute only on banking days. `all-days` will execute 365 days a year.

# Why Are Changes Being Made
Allow for sending files to ODFI on non-banking days./