### PR TITLE
feat: Add configurable file cleanup service to prevent storage exhaustion

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,11 +42,6 @@ jobs:
       if: runner.os == 'Linux'
       run: make check
 
-    - name: Cleanup Service Tests
-      if: runner.os == 'Windows'
-      run: |
-        go test ./internal/pipeline/... -count 1 -v -run TestCleanupService
-
     - name: Go Tests
       if: runner.os != 'Linux'
       run: go test ./... -count 1 -short

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,6 +42,11 @@ jobs:
       if: runner.os == 'Linux'
       run: make check
 
+    - name: Cleanup Service Tests
+      if: runner.os == 'Windows'
+      run: |
+        go test ./internal/pipeline/... -count 1 -v -run TestCleanupService
+
     - name: Go Tests
       if: runner.os != 'Linux'
       run: go test ./... -count 1 -short

--- a/docs/_data/docs-menu.yml
+++ b/docs/_data/docs-menu.yml
@@ -46,6 +46,8 @@
       link: /ops/merging/
     - name: File Options
       link: /ops/file-options/
+    - name: File Cleanup
+      link: /ops/cleanup/
 
 - label: Production
   items:

--- a/docs/ops/cleanup.md
+++ b/docs/ops/cleanup.md
@@ -1,0 +1,102 @@
+---
+layout: page
+title: File Cleanup
+---
+
+# File Cleanup
+
+ACH Gateway includes an optional cleanup feature that automatically removes old processed files from the storage directory. This helps prevent file descriptor exhaustion and disk space issues in long-running deployments.
+
+## Overview
+
+When ACH files are processed at cutoff times, they are moved from the `mergable/<shard-name>/` directory to isolated directories with timestamps (e.g., `<shard-name>-20240115-143000/`). After successful upload to the ODFI and audit storage, these directories remain on disk indefinitely by default.
+
+The cleanup feature periodically scans for these isolated directories and removes those that:
+1. Are older than the configured retention duration
+2. Have been successfully processed (contain an `uploaded/` subdirectory)
+
+## Configuration
+
+The cleanup feature is configured per shard in the `Upload.merging.cleanup` section:
+
+```yaml
+Upload:
+  merging:
+    directory: "./storage/"
+    cleanup:
+      enabled: true                    # Enable/disable cleanup
+      retentionDuration: "24h"         # How long to keep files after processing
+      checkInterval: "1h"              # How often to run cleanup
+```
+
+### Configuration Options
+
+- **enabled**: Boolean flag to enable or disable the cleanup feature (default: `false`)
+- **retentionDuration**: Duration string specifying how long to retain processed files (e.g., "24h", "7d", "168h")
+- **checkInterval**: Duration string specifying how often to run the cleanup process (e.g., "1h", "30m")
+
+### Example Configurations
+
+#### Basic cleanup - 24 hour retention
+```yaml
+Upload:
+  merging:
+    cleanup:
+      enabled: true
+      retentionDuration: "24h"
+      checkInterval: "1h"
+```
+
+#### Aggressive cleanup - 1 hour retention
+```yaml
+Upload:
+  merging:
+    cleanup:
+      enabled: true
+      retentionDuration: "1h"
+      checkInterval: "15m"
+```
+
+#### Weekly cleanup - 7 day retention
+```yaml
+Upload:
+  merging:
+    cleanup:
+      enabled: true
+      retentionDuration: "168h"  # 7 days
+      checkInterval: "24h"       # Daily check
+```
+
+## Safety Features
+
+The cleanup service includes several safety features to prevent accidental data loss:
+
+1. **Pattern Matching**: Only directories matching the pattern `<shard-name>-YYYYMMDD-HHMMSS` are considered for cleanup
+2. **Upload Verification**: Directories are only deleted if they contain an `uploaded/` subdirectory with files, indicating successful processing
+3. **Age Check**: Files must be older than the retention duration based on the timestamp in the directory name
+4. **Active Directory Protection**: The `mergable/` directories used for active processing are never deleted
+
+## Monitoring
+
+The cleanup service exposes Prometheus metrics for monitoring:
+
+- `achgateway_cleanup_runs_total`: Total number of cleanup runs executed (labeled by shard and status)
+- `achgateway_cleanup_directories_deleted_total`: Total number of directories deleted (labeled by shard)
+- `achgateway_cleanup_errors_total`: Total number of errors during cleanup (labeled by shard and error type)
+
+## Logging
+
+The cleanup service logs its activities at various levels:
+
+- **INFO**: Service start/stop, cleanup run summaries, directory deletions
+- **DEBUG**: Individual directory checks
+- **WARN**: Non-fatal errors during directory checks
+- **ERROR**: Fatal errors preventing cleanup
+
+Example log entries:
+```
+INFO starting cleanup service shard=production checkInterval=1h retentionDuration=24h
+INFO starting cleanup run shard=production
+INFO deleting directory shard=production directory=production-20240114-143000
+INFO completed cleanup run shard=production deleted=5 errors=0 duration=1.2s
+```

--- a/examples/getting-started/config.yml
+++ b/examples/getting-started/config.yml
@@ -71,3 +71,7 @@ ACHGateway:
           return: "/returned/"
     merging:
       directory: "./storage/"
+      cleanup:
+        enabled: false              # Set to true to enable automatic cleanup
+        retentionDuration: "24h"    # Keep files for 24 hours after processing
+        checkInterval: "1h"         # Check for files to clean up every hour

--- a/go.sum
+++ b/go.sum
@@ -849,8 +849,6 @@ github.com/go-latex/latex v0.0.0-20210823091927-c0d11ff05a81/go.mod h1:SX0U8uGpx
 github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
 github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
-github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -1307,8 +1305,6 @@ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.6
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0/go.mod h1:rg+RlpR5dKwaS95IyyZqj5Wd4E13lk/msnTS0Xl9lJM=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 h1:sbiXRNDSWJOTobXh5HyQKjq6wUC5tNybqjIqDpAY4CU=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0/go.mod h1:69uWxva0WgAA/4bu2Yy70SLDBwZXuQ6PbBpbsa5iZrQ=
-go.opentelemetry.io/otel v1.36.0 h1:UumtzIklRBY6cI/lllNZlALOF5nNIzJVb16APdvgTXg=
-go.opentelemetry.io/otel v1.36.0/go.mod h1:/TcFMXYjyRNh8khOAO9ybYkqaDBb/70aVwkNML4pP8E=
 go.opentelemetry.io/otel v1.37.0 h1:9zhNfelUvx0KBfu/gb+ZgeAfAgtWrfHJZcAqFC228wQ=
 go.opentelemetry.io/otel v1.37.0/go.mod h1:ehE/umFRLnuLa/vSccNq9oS1ErUlkkK71gMcN34UG8I=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0 h1:dNzwXjZKpMpE2JhmO+9HsPl42NIXFIFSUSSs0fiqra0=
@@ -1319,16 +1315,12 @@ go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.35.0 h1:PB3Zrjs1sG1GBX
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.35.0/go.mod h1:U2R3XyVPzn0WX7wOIypPuptulsMcPDPs/oiSVOMVnHY=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.36.0 h1:G8Xec/SgZQricwWBJF/mHZc7A02YHedfFDENwJEdRA0=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.36.0/go.mod h1:PD57idA/AiFD5aqoxGxCvT/ILJPeHy3MjqU/NS7KogY=
-go.opentelemetry.io/otel/metric v1.36.0 h1:MoWPKVhQvJ+eeXWHFBOPoBOi20jh6Iq2CcCREuTYufE=
-go.opentelemetry.io/otel/metric v1.36.0/go.mod h1:zC7Ks+yeyJt4xig9DEw9kuUFe5C3zLbVjV2PzT6qzbs=
 go.opentelemetry.io/otel/metric v1.37.0 h1:mvwbQS5m0tbmqML4NqK+e3aDiO02vsf/WgbsdpcPoZE=
 go.opentelemetry.io/otel/metric v1.37.0/go.mod h1:04wGrZurHYKOc+RKeye86GwKiTb9FKm1WHtO+4EVr2E=
 go.opentelemetry.io/otel/sdk v1.36.0 h1:b6SYIuLRs88ztox4EyrvRti80uXIFy+Sqzoh9kFULbs=
 go.opentelemetry.io/otel/sdk v1.36.0/go.mod h1:+lC+mTgD+MUWfjJubi2vvXWcVxyr9rmlshZni72pXeY=
 go.opentelemetry.io/otel/sdk/metric v1.35.0 h1:1RriWBmCKgkeHEhM7a2uMjMUfP7MsOF5JpUCaEqEI9o=
 go.opentelemetry.io/otel/sdk/metric v1.35.0/go.mod h1:is6XYCUMpcKi+ZsOvfluY5YstFnhW0BidkR+gL+qN+w=
-go.opentelemetry.io/otel/trace v1.36.0 h1:ahxWNuqZjpdiFAyrIoQ4GIiAIhxAunQR6MUoKrsNd4w=
-go.opentelemetry.io/otel/trace v1.36.0/go.mod h1:gQ+OnDZzrybY4k4seLzPAWNwVBBVlF2szhehOBB/tGA=
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=

--- a/internal/pipeline/cleanup.go
+++ b/internal/pipeline/cleanup.go
@@ -1,0 +1,353 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/moov-io/achgateway/internal/service"
+	"github.com/moov-io/achgateway/internal/storage"
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/base/telemetry"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var (
+	cleanupRunsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "achgateway_cleanup_runs_total",
+		Help: "Total number of cleanup runs executed",
+	}, []string{"shard", "status"})
+
+	cleanupDirectoriesDeletedCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "achgateway_cleanup_directories_deleted_total",
+		Help: "Total number of directories deleted by cleanup",
+	}, []string{"shard"})
+
+	cleanupErrorsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "achgateway_cleanup_errors_total",
+		Help: "Total number of errors during cleanup",
+	}, []string{"shard", "error_type"})
+)
+
+// CleanupService manages the periodic cleanup of old processed ACH files
+type CleanupService struct {
+	logger  log.Logger
+	storage storage.Chest
+	shard   service.Shard
+	config  *service.CleanupConfig
+	ticker  *time.Ticker
+	done    chan struct{}
+
+	// directoryPattern matches directories created by isolateMergableDir
+	// Format: <shard-name>-YYYYMMDD-HHMMSS
+	directoryPattern *regexp.Regexp
+}
+
+// NewCleanupService creates a new cleanup service for a shard
+func NewCleanupService(logger log.Logger, storage storage.Chest, shard service.Shard, config *service.CleanupConfig) (*CleanupService, error) {
+	if config == nil || !config.Enabled {
+		return nil, nil
+	}
+
+	// Create pattern to match isolated directories
+	pattern := fmt.Sprintf("^%s-\\d{8}-\\d{6}$", regexp.QuoteMeta(shard.Name))
+	dirPattern, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile directory pattern: %w", err)
+	}
+
+	return &CleanupService{
+		logger:           logger,
+		storage:          storage,
+		shard:            shard,
+		config:           config,
+		directoryPattern: dirPattern,
+		done:             make(chan struct{}),
+	}, nil
+}
+
+// Start begins the periodic cleanup process
+func (cs *CleanupService) Start(ctx context.Context) {
+	if cs == nil {
+		return
+	}
+
+	cs.ticker = time.NewTicker(cs.config.CheckInterval)
+
+	cs.logger.Info().With(log.Fields{
+		"shard":             log.String(cs.shard.Name),
+		"checkInterval":     log.String(cs.config.CheckInterval.String()),
+		"retentionDuration": log.String(cs.config.RetentionDuration.String()),
+	}).Log("starting cleanup service")
+
+	// Run initial cleanup
+	cs.runCleanup(ctx)
+
+	go func() {
+		for {
+			select {
+			case <-cs.ticker.C:
+				cs.runCleanup(ctx)
+			case <-ctx.Done():
+				cs.Stop()
+				return
+			case <-cs.done:
+				return
+			}
+		}
+	}()
+}
+
+// Stop halts the cleanup service
+func (cs *CleanupService) Stop() {
+	if cs == nil {
+		return
+	}
+
+	cs.logger.Info().With(log.Fields{
+		"shard": log.String(cs.shard.Name),
+	}).Log("stopping cleanup service")
+
+	if cs.ticker != nil {
+		cs.ticker.Stop()
+	}
+	close(cs.done)
+}
+
+// runCleanup performs a single cleanup run
+func (cs *CleanupService) runCleanup(ctx context.Context) {
+	ctx, span := telemetry.StartSpan(ctx, "cleanup-run", trace.WithAttributes(
+		attribute.String("achgateway.shard", cs.shard.Name),
+	))
+	defer span.End()
+
+	cs.logger.Debug().With(log.Fields{
+		"shard": log.String(cs.shard.Name),
+	}).Log("starting cleanup run")
+
+	startTime := time.Now()
+	deletedCount := 0
+	errorCount := 0
+
+	// List all directories in the storage root
+	entries, err := cs.storage.ReadDir(".")
+	if err != nil {
+		cs.logger.Error().With(log.Fields{
+			"shard": log.String(cs.shard.Name),
+		}).LogErrorf("failed to read storage directory: %v", err)
+		cleanupRunsCounter.WithLabelValues(cs.shard.Name, "error").Inc()
+		cleanupErrorsCounter.WithLabelValues(cs.shard.Name, "read_dir").Inc()
+		span.RecordError(err)
+		return
+	}
+
+	cutoffTime := time.Now().Add(-cs.config.RetentionDuration)
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		dirName := entry.Name()
+
+		// Skip if directory doesn't match our pattern
+		if !cs.directoryPattern.MatchString(dirName) {
+			continue
+		}
+
+		// Check if directory should be deleted
+		if shouldDelete, err := cs.shouldDeleteDirectory(ctx, dirName, cutoffTime); err != nil {
+			cs.logger.Warn().With(log.Fields{
+				"shard":     log.String(cs.shard.Name),
+				"directory": log.String(dirName),
+			}).Logf("error checking directory: %v", err)
+			errorCount++
+			cleanupErrorsCounter.WithLabelValues(cs.shard.Name, "check_directory").Inc()
+		} else if shouldDelete {
+			if err := cs.deleteDirectory(ctx, dirName); err != nil {
+				cs.logger.Error().With(log.Fields{
+					"shard":     log.String(cs.shard.Name),
+					"directory": log.String(dirName),
+				}).LogErrorf("failed to delete directory: %v", err)
+				errorCount++
+				cleanupErrorsCounter.WithLabelValues(cs.shard.Name, "delete_directory").Inc()
+			} else {
+				deletedCount++
+				cleanupDirectoriesDeletedCounter.WithLabelValues(cs.shard.Name).Inc()
+			}
+		}
+	}
+
+	duration := time.Since(startTime)
+
+	cs.logger.Info().With(log.Fields{
+		"shard":    log.String(cs.shard.Name),
+		"deleted":  log.Int(deletedCount),
+		"errors":   log.Int(errorCount),
+		"duration": log.String(duration.String()),
+	}).Log("completed cleanup run")
+
+	span.SetAttributes(
+		attribute.Int("achgateway.cleanup.deleted_count", deletedCount),
+		attribute.Int("achgateway.cleanup.error_count", errorCount),
+		attribute.String("achgateway.cleanup.duration", duration.String()),
+	)
+
+	if errorCount == 0 {
+		cleanupRunsCounter.WithLabelValues(cs.shard.Name, "success").Inc()
+	} else {
+		cleanupRunsCounter.WithLabelValues(cs.shard.Name, "partial_error").Inc()
+	}
+}
+
+// shouldDeleteDirectory determines if a directory should be deleted based on:
+// 1. Directory age (older than retention duration)
+// 2. Presence of uploaded/ subdirectory (indicates successful processing)
+// 3. Directory timestamp parsed from name
+func (cs *CleanupService) shouldDeleteDirectory(ctx context.Context, dirName string, cutoffTime time.Time) (bool, error) {
+	_, span := telemetry.StartSpan(ctx, "check-directory", trace.WithAttributes(
+		attribute.String("achgateway.shard", cs.shard.Name),
+		attribute.String("achgateway.directory", dirName),
+	))
+	defer span.End()
+
+	// Parse timestamp from directory name
+	// Format: <shard-name>-YYYYMMDD-HHMMSS
+	timestampStr := dirName[len(cs.shard.Name)+1:] // Skip shard name and hyphen
+	dirTime, err := time.Parse("20060102-150405", timestampStr)
+	if err != nil {
+		span.RecordError(err)
+		return false, fmt.Errorf("failed to parse directory timestamp: %w", err)
+	}
+
+	// Check if directory is old enough
+	if dirTime.After(cutoffTime) {
+		span.SetAttributes(
+			attribute.Bool("achgateway.cleanup.too_new", true),
+			attribute.String("achgateway.cleanup.dir_time", dirTime.String()),
+			attribute.String("achgateway.cleanup.cutoff_time", cutoffTime.String()),
+		)
+		return false, nil
+	}
+
+	// Check for uploaded/ subdirectory
+	uploadedPath := filepath.Join(dirName, "uploaded")
+	entries, err := cs.storage.ReadDir(uploadedPath)
+	if err != nil {
+		// If we can't read the uploaded directory, it might not exist
+		// which means the files weren't successfully processed
+		span.SetAttributes(attribute.Bool("achgateway.cleanup.uploaded_dir_exists", false))
+		return false, nil
+	}
+
+	// Ensure there are files in the uploaded directory
+	hasUploadedFiles := false
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			hasUploadedFiles = true
+			break
+		}
+	}
+
+	span.SetAttributes(
+		attribute.Bool("achgateway.cleanup.uploaded_dir_exists", true),
+		attribute.Bool("achgateway.cleanup.has_uploaded_files", hasUploadedFiles),
+		attribute.String("achgateway.cleanup.dir_time", dirTime.String()),
+		attribute.String("achgateway.cleanup.cutoff_time", cutoffTime.String()),
+	)
+
+	return hasUploadedFiles, nil
+}
+
+// deleteDirectory removes a directory and all its contents
+func (cs *CleanupService) deleteDirectory(ctx context.Context, dirName string) error {
+	_, span := telemetry.StartSpan(ctx, "delete-directory", trace.WithAttributes(
+		attribute.String("achgateway.shard", cs.shard.Name),
+		attribute.String("achgateway.directory", dirName),
+	))
+	defer span.End()
+
+	cs.logger.Info().With(log.Fields{
+		"shard":     log.String(cs.shard.Name),
+		"directory": log.String(dirName),
+	}).Log("deleting directory")
+
+	err := cs.storage.RmdirAll(dirName)
+	if err != nil {
+		span.RecordError(err)
+		return err
+	}
+
+	return nil
+}
+
+// GetStats returns current statistics about directories that could be cleaned up
+func (cs *CleanupService) GetStats(ctx context.Context) (*CleanupStats, error) {
+	if cs == nil {
+		return nil, nil
+	}
+
+	stats := &CleanupStats{
+		ShardName:         cs.shard.Name,
+		RetentionDuration: cs.config.RetentionDuration,
+	}
+
+	entries, err := cs.storage.ReadDir(".")
+	if err != nil {
+		return nil, err
+	}
+
+	cutoffTime := time.Now().Add(-cs.config.RetentionDuration)
+
+	for _, entry := range entries {
+		if !entry.IsDir() || !cs.directoryPattern.MatchString(entry.Name()) {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
+		stats.TotalDirectories++
+
+		if shouldDelete, err := cs.shouldDeleteDirectory(ctx, entry.Name(), cutoffTime); err == nil && shouldDelete {
+			stats.EligibleForDeletion++
+			stats.TotalSize += info.Size()
+		}
+	}
+
+	return stats, nil
+}
+
+// CleanupStats contains statistics about cleanup operations
+type CleanupStats struct {
+	ShardName           string
+	TotalDirectories    int
+	EligibleForDeletion int
+	TotalSize           int64
+	RetentionDuration   time.Duration
+}

--- a/internal/pipeline/cleanup.go
+++ b/internal/pipeline/cleanup.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
+	"path"
 	"regexp"
 	"time"
 
@@ -242,7 +242,7 @@ func (cs *CleanupService) shouldDeleteDirectory(ctx context.Context, dirName str
 
 	// Extract just the directory name in case we got a full path
 	// This is important for Windows compatibility where dirName might be a full path
-	baseName := filepath.Base(dirName)
+	baseName := path.Base(dirName)
 
 	// Parse timestamp from directory name
 	// Format: <shard-name>-YYYYMMDD-HHMMSS
@@ -268,7 +268,7 @@ func (cs *CleanupService) shouldDeleteDirectory(ctx context.Context, dirName str
 	}
 
 	// Check for uploaded/ subdirectory
-	uploadedPath := filepath.Join(dirName, "uploaded")
+	uploadedPath := path.Join(dirName, "uploaded")
 	entries, err := cs.storage.ReadDir(uploadedPath)
 	if err != nil {
 		// If we can't read the uploaded directory, it might not exist

--- a/internal/pipeline/cleanup_test.go
+++ b/internal/pipeline/cleanup_test.go
@@ -20,7 +20,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"testing"
 	"time"
 
@@ -90,17 +90,17 @@ func TestCleanupService_shouldDeleteDirectory(t *testing.T) {
 	newDirName := fmt.Sprintf("%s-%s", shard.Name, now.Add(-1*time.Hour).Format("20060102-150405"))
 
 	// Create old directory with uploaded files
-	oldUploadedPath := filepath.Join(oldDirName, "uploaded")
+	oldUploadedPath := path.Join(oldDirName, "uploaded")
 	err = storage.MkdirAll(oldUploadedPath)
 	require.NoError(t, err)
-	err = storage.WriteFile(filepath.Join(oldUploadedPath, "test.ach"), []byte("test content"))
+	err = storage.WriteFile(path.Join(oldUploadedPath, "test.ach"), []byte("test content"))
 	require.NoError(t, err)
 
 	// Create new directory with uploaded files
-	newUploadedPath := filepath.Join(newDirName, "uploaded")
+	newUploadedPath := path.Join(newDirName, "uploaded")
 	err = storage.MkdirAll(newUploadedPath)
 	require.NoError(t, err)
-	err = storage.WriteFile(filepath.Join(newUploadedPath, "test.ach"), []byte("test content"))
+	err = storage.WriteFile(path.Join(newUploadedPath, "test.ach"), []byte("test content"))
 	require.NoError(t, err)
 
 	// Create directory without uploaded subdirectory (use different timestamp to avoid conflict)
@@ -154,26 +154,26 @@ func TestCleanupService_runCleanup(t *testing.T) {
 	// Create directories to test
 	// 1. Old directory with uploaded files (should be deleted)
 	oldDir1 := fmt.Sprintf("%s-%s", shard.Name, now.Add(-48*time.Hour).Format("20060102-150405"))
-	oldUploadedPath1 := filepath.Join(oldDir1, "uploaded")
+	oldUploadedPath1 := path.Join(oldDir1, "uploaded")
 	err = storage.MkdirAll(oldUploadedPath1)
 	require.NoError(t, err)
-	err = storage.WriteFile(filepath.Join(oldUploadedPath1, "test1.ach"), []byte("test content 1"))
+	err = storage.WriteFile(path.Join(oldUploadedPath1, "test1.ach"), []byte("test content 1"))
 	require.NoError(t, err)
 
 	// 2. Another old directory with uploaded files (should be deleted)
 	oldDir2 := fmt.Sprintf("%s-%s", shard.Name, now.Add(-72*time.Hour).Format("20060102-150405"))
-	oldUploadedPath2 := filepath.Join(oldDir2, "uploaded")
+	oldUploadedPath2 := path.Join(oldDir2, "uploaded")
 	err = storage.MkdirAll(oldUploadedPath2)
 	require.NoError(t, err)
-	err = storage.WriteFile(filepath.Join(oldUploadedPath2, "test2.ach"), []byte("test content 2"))
+	err = storage.WriteFile(path.Join(oldUploadedPath2, "test2.ach"), []byte("test content 2"))
 	require.NoError(t, err)
 
 	// 3. New directory (should not be deleted)
 	newDir := fmt.Sprintf("%s-%s", shard.Name, now.Add(-1*time.Hour).Format("20060102-150405"))
-	newUploadedPath := filepath.Join(newDir, "uploaded")
+	newUploadedPath := path.Join(newDir, "uploaded")
 	err = storage.MkdirAll(newUploadedPath)
 	require.NoError(t, err)
-	err = storage.WriteFile(filepath.Join(newUploadedPath, "test3.ach"), []byte("test content 3"))
+	err = storage.WriteFile(path.Join(newUploadedPath, "test3.ach"), []byte("test content 3"))
 	require.NoError(t, err)
 
 	// 4. Old directory without uploaded files (should not be deleted)
@@ -237,10 +237,10 @@ func TestCleanupService_GetStats(t *testing.T) {
 	// Create test directories
 	// Old directory eligible for deletion
 	oldDir := fmt.Sprintf("%s-%s", shard.Name, now.Add(-48*time.Hour).Format("20060102-150405"))
-	oldUploadedPath := filepath.Join(oldDir, "uploaded")
+	oldUploadedPath := path.Join(oldDir, "uploaded")
 	err = storage.MkdirAll(oldUploadedPath)
 	require.NoError(t, err)
-	err = storage.WriteFile(filepath.Join(oldUploadedPath, "test.ach"), []byte("test content"))
+	err = storage.WriteFile(path.Join(oldUploadedPath, "test.ach"), []byte("test content"))
 	require.NoError(t, err)
 
 	// New directory not eligible

--- a/internal/pipeline/cleanup_test.go
+++ b/internal/pipeline/cleanup_test.go
@@ -1,0 +1,299 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/moov-io/achgateway/internal/service"
+	"github.com/moov-io/achgateway/internal/storage"
+	"github.com/moov-io/base/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupService_NewCleanupService(t *testing.T) {
+	logger := log.NewTestLogger()
+	storage, err := storage.NewFilesystem(t.TempDir())
+	require.NoError(t, err)
+
+	shard := service.Shard{
+		Name: "test-shard",
+	}
+
+	// Test with nil config
+	cs, err := NewCleanupService(logger, storage, shard, nil)
+	require.NoError(t, err)
+	require.Nil(t, cs)
+
+	// Test with disabled config
+	config := &service.CleanupConfig{
+		Enabled: false,
+	}
+	cs, err = NewCleanupService(logger, storage, shard, config)
+	require.NoError(t, err)
+	require.Nil(t, cs)
+
+	// Test with enabled config
+	config = &service.CleanupConfig{
+		Enabled:           true,
+		RetentionDuration: 24 * time.Hour,
+		CheckInterval:     1 * time.Hour,
+	}
+	cs, err = NewCleanupService(logger, storage, shard, config)
+	require.NoError(t, err)
+	require.NotNil(t, cs)
+	require.NotNil(t, cs.directoryPattern)
+}
+
+func TestCleanupService_shouldDeleteDirectory(t *testing.T) {
+	logger := log.NewTestLogger()
+	tempDir := t.TempDir()
+	storage, err := storage.NewFilesystem(tempDir)
+	require.NoError(t, err)
+
+	shard := service.Shard{
+		Name: "test-shard",
+	}
+	config := &service.CleanupConfig{
+		Enabled:           true,
+		RetentionDuration: 24 * time.Hour,
+		CheckInterval:     1 * time.Hour,
+	}
+
+	cs, err := NewCleanupService(logger, storage, shard, config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create test directories
+	now := time.Now()
+	oldDirName := fmt.Sprintf("%s-%s", shard.Name, now.Add(-48*time.Hour).Format("20060102-150405"))
+	newDirName := fmt.Sprintf("%s-%s", shard.Name, now.Add(-1*time.Hour).Format("20060102-150405"))
+
+	// Create old directory with uploaded files
+	oldUploadedPath := filepath.Join(oldDirName, "uploaded")
+	err = storage.MkdirAll(oldUploadedPath)
+	require.NoError(t, err)
+	err = storage.WriteFile(filepath.Join(oldUploadedPath, "test.ach"), []byte("test content"))
+	require.NoError(t, err)
+
+	// Create new directory with uploaded files
+	newUploadedPath := filepath.Join(newDirName, "uploaded")
+	err = storage.MkdirAll(newUploadedPath)
+	require.NoError(t, err)
+	err = storage.WriteFile(filepath.Join(newUploadedPath, "test.ach"), []byte("test content"))
+	require.NoError(t, err)
+
+	// Create directory without uploaded subdirectory (use different timestamp to avoid conflict)
+	nouploadDirName := fmt.Sprintf("%s-%s", shard.Name, now.Add(-36*time.Hour).Format("20060102-150405"))
+	err = storage.MkdirAll(nouploadDirName)
+	require.NoError(t, err)
+
+	cutoffTime := now.Add(-config.RetentionDuration)
+
+	// Test old directory with uploaded files - should delete
+	shouldDelete, err := cs.shouldDeleteDirectory(ctx, oldDirName, cutoffTime)
+	require.NoError(t, err)
+	require.True(t, shouldDelete)
+
+	// Test new directory - should not delete (too new)
+	shouldDelete, err = cs.shouldDeleteDirectory(ctx, newDirName, cutoffTime)
+	require.NoError(t, err)
+	require.False(t, shouldDelete)
+
+	// Test directory without uploaded subdirectory - should not delete
+	shouldDelete, err = cs.shouldDeleteDirectory(ctx, nouploadDirName, cutoffTime)
+	require.NoError(t, err)
+	require.False(t, shouldDelete)
+
+	// Test invalid directory name format
+	_, err = cs.shouldDeleteDirectory(ctx, "invalid-dir-name", cutoffTime)
+	require.Error(t, err)
+}
+
+func TestCleanupService_runCleanup(t *testing.T) {
+	logger := log.NewTestLogger()
+	tempDir := t.TempDir()
+	storage, err := storage.NewFilesystem(tempDir)
+	require.NoError(t, err)
+
+	shard := service.Shard{
+		Name: "test-shard",
+	}
+	config := &service.CleanupConfig{
+		Enabled:           true,
+		RetentionDuration: 24 * time.Hour,
+		CheckInterval:     1 * time.Hour,
+	}
+
+	cs, err := NewCleanupService(logger, storage, shard, config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	now := time.Now()
+
+	// Create directories to test
+	// 1. Old directory with uploaded files (should be deleted)
+	oldDir1 := fmt.Sprintf("%s-%s", shard.Name, now.Add(-48*time.Hour).Format("20060102-150405"))
+	oldUploadedPath1 := filepath.Join(oldDir1, "uploaded")
+	err = storage.MkdirAll(oldUploadedPath1)
+	require.NoError(t, err)
+	err = storage.WriteFile(filepath.Join(oldUploadedPath1, "test1.ach"), []byte("test content 1"))
+	require.NoError(t, err)
+
+	// 2. Another old directory with uploaded files (should be deleted)
+	oldDir2 := fmt.Sprintf("%s-%s", shard.Name, now.Add(-72*time.Hour).Format("20060102-150405"))
+	oldUploadedPath2 := filepath.Join(oldDir2, "uploaded")
+	err = storage.MkdirAll(oldUploadedPath2)
+	require.NoError(t, err)
+	err = storage.WriteFile(filepath.Join(oldUploadedPath2, "test2.ach"), []byte("test content 2"))
+	require.NoError(t, err)
+
+	// 3. New directory (should not be deleted)
+	newDir := fmt.Sprintf("%s-%s", shard.Name, now.Add(-1*time.Hour).Format("20060102-150405"))
+	newUploadedPath := filepath.Join(newDir, "uploaded")
+	err = storage.MkdirAll(newUploadedPath)
+	require.NoError(t, err)
+	err = storage.WriteFile(filepath.Join(newUploadedPath, "test3.ach"), []byte("test content 3"))
+	require.NoError(t, err)
+
+	// 4. Old directory without uploaded files (should not be deleted)
+	oldDirNoUpload := fmt.Sprintf("%s-%s", shard.Name, now.Add(-36*time.Hour).Format("20060102-150405"))
+	err = storage.MkdirAll(oldDirNoUpload)
+	require.NoError(t, err)
+
+	// 5. Directory that doesn't match pattern (should be ignored)
+	ignoredDir := "some-other-directory"
+	err = storage.MkdirAll(ignoredDir)
+	require.NoError(t, err)
+
+	// 6. Regular file (should be ignored)
+	err = storage.WriteFile("regular-file.txt", []byte("test"))
+	require.NoError(t, err)
+
+	// Run cleanup
+	cs.runCleanup(ctx)
+
+	// Verify results
+	entries, err := storage.ReadDir(".")
+	require.NoError(t, err)
+
+	dirNames := make(map[string]bool)
+	for _, entry := range entries {
+		dirNames[entry.Name()] = true
+	}
+
+	// Old directories with uploaded files should be deleted
+	require.False(t, dirNames[oldDir1], "oldDir1 should have been deleted")
+	require.False(t, dirNames[oldDir2], "oldDir2 should have been deleted")
+
+	// These should still exist
+	require.True(t, dirNames[newDir], "newDir should still exist")
+	require.True(t, dirNames[oldDirNoUpload], "oldDirNoUpload should still exist")
+	require.True(t, dirNames[ignoredDir], "ignoredDir should still exist")
+	require.True(t, dirNames["regular-file.txt"], "regular-file.txt should still exist")
+}
+
+func TestCleanupService_GetStats(t *testing.T) {
+	logger := log.NewTestLogger()
+	tempDir := t.TempDir()
+	storage, err := storage.NewFilesystem(tempDir)
+	require.NoError(t, err)
+
+	shard := service.Shard{
+		Name: "test-shard",
+	}
+	config := &service.CleanupConfig{
+		Enabled:           true,
+		RetentionDuration: 24 * time.Hour,
+		CheckInterval:     1 * time.Hour,
+	}
+
+	cs, err := NewCleanupService(logger, storage, shard, config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	now := time.Now()
+
+	// Create test directories
+	// Old directory eligible for deletion
+	oldDir := fmt.Sprintf("%s-%s", shard.Name, now.Add(-48*time.Hour).Format("20060102-150405"))
+	oldUploadedPath := filepath.Join(oldDir, "uploaded")
+	err = storage.MkdirAll(oldUploadedPath)
+	require.NoError(t, err)
+	err = storage.WriteFile(filepath.Join(oldUploadedPath, "test.ach"), []byte("test content"))
+	require.NoError(t, err)
+
+	// New directory not eligible
+	newDir := fmt.Sprintf("%s-%s", shard.Name, now.Add(-1*time.Hour).Format("20060102-150405"))
+	err = storage.MkdirAll(newDir)
+	require.NoError(t, err)
+
+	// Get stats
+	stats, err := cs.GetStats(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+
+	require.Equal(t, shard.Name, stats.ShardName)
+	require.Equal(t, 2, stats.TotalDirectories)
+	require.Equal(t, 1, stats.EligibleForDeletion)
+	require.Equal(t, config.RetentionDuration, stats.RetentionDuration)
+}
+
+func TestCleanupService_StartStop(t *testing.T) {
+	logger := log.NewTestLogger()
+	tempDir := t.TempDir()
+	storage, err := storage.NewFilesystem(tempDir)
+	require.NoError(t, err)
+
+	shard := service.Shard{
+		Name: "test-shard",
+	}
+	config := &service.CleanupConfig{
+		Enabled:           true,
+		RetentionDuration: 24 * time.Hour,
+		CheckInterval:     100 * time.Millisecond, // Short interval for testing
+	}
+
+	cs, err := NewCleanupService(logger, storage, shard, config)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start the service
+	cs.Start(ctx)
+
+	// Let it run for a bit
+	time.Sleep(250 * time.Millisecond)
+
+	// Stop the service
+	cs.Stop()
+
+	// Verify it stopped
+	select {
+	case <-cs.done:
+		// Good, it's closed
+	case <-time.After(1 * time.Second):
+		t.Fatal("cleanup service did not stop in time")
+	}
+}


### PR DESCRIPTION
Adds an optional cleanup service that automatically removes processed ACH files after a configurable retention period to prevent file descriptor exhaustion in long-running deployments. The service runs periodically, safely deleting only successfully uploaded files older than the retention duration (e.g., 24 hours).  Intended to be used alongside an audit mechanism such as GCS buckets to retain files long term. The feature is disabled by default.

TODO:

- [x] Fix for Windows 😮‍💨 