### PR TITLE
notify: use reflect.TypeOf rather than %T

### DIFF
--- a/internal/notify/multi.go
+++ b/internal/notify/multi.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/moov-io/achgateway/internal/service"
@@ -74,8 +75,16 @@ func setupBackoff(cfg *service.NotificationRetries) (retry.Backoff, error) {
 
 func (ms *MultiSender) senderTypes() string {
 	out := make([]string, len(ms.senders))
-	for i := range ms.senders {
-		out[i] = fmt.Sprintf("%T", ms.senders[i])
+	for i, sender := range ms.senders {
+		// Get the type of each sender
+		typeName := reflect.TypeOf(sender).Name()
+		if typeName == "" {
+			// Handle pointer types by getting the element type
+			if reflect.TypeOf(sender).Kind() == reflect.Ptr {
+				typeName = reflect.TypeOf(sender).Elem().Name()
+			}
+		}
+		out[i] = typeName
 	}
 	return strings.Join(out, ", ")
 }

--- a/internal/notify/multi_test.go
+++ b/internal/notify/multi_test.go
@@ -50,10 +50,12 @@ func TestMultiSender_senderTypes(t *testing.T) {
 		Email: []string{"testing"},
 	}
 
-	sender, err := NewMultiSender(logger, cfg, notifiers)
+	ms, err := NewMultiSender(logger, cfg, notifiers)
 	require.NoError(t, err)
 
-	require.Equal(t, "*notify.Email", sender.senderTypes()) // no password leaked
+	ms.senders = append(ms.senders, &MockSender{})
+
+	require.Equal(t, "Email, MockSender", ms.senderTypes()) // no password leaked
 }
 
 func TestMultiSenderErr(t *testing.T) {


### PR DESCRIPTION
CodeQL seems to think that `%T` can expose struct fields, which it cannot.


