### PR TITLE
pre-allocate shards in listShards function

### DIFF
--- a/internal/pipeline/pending_files_api.go
+++ b/internal/pipeline/pending_files_api.go
@@ -44,7 +44,7 @@ type shard struct {
 
 func (fr *FileReceiver) listShards() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var shards []shard
+		shards := make([]shard, 0, len(fr.shardAggregators))
 
 		for name := range fr.shardAggregators {
 			shards = append(shards, shard{


### PR DESCRIPTION
# Changes
Updates the `shards` array in `listShards` to pre-allocate since its size can be known ahead of time.
# Why Are Changes Being Made
Since the length of `shards` can be known ahead of time, it is better from a performance standpoint to pre-allocate and avoid re-allocating the array.

`make check` is failing because of this
<img width="1220" height="204" alt="image" src="https://github.com/user-attachments/assets/cd864394-428f-4ece-b8d2-4169dd31f9d8" />

