### PR TITLE
feat: add ARM64 support for Docker images and binary releases (#159)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,21 @@ jobs:
         asset_name: achgateway-linux-amd64
         asset_content_type: application/octet-stream
 
+    - name: Build Linux ARM64 Binary
+      if: runner.os == 'Linux'
+      run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod=vendor -ldflags "-X github.com/moov-io/achgateway.Version=${GITHUB_REF#refs/tags/}" -o bin/achgateway-linux-arm64 ./cmd/achgateway/
+
+    - name: Upload Linux ARM64 Binary
+      if: runner.os == 'Linux'
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get_release_info.outputs.upload_url }}
+        asset_path: ./bin/achgateway-linux-arm64
+        asset_name: achgateway-linux-arm64
+        asset_content_type: application/octet-stream
+
     - name: Upload macOS Binary
       if: runner.os == 'macOS'
       uses: actions/upload-release-asset@v1
@@ -135,29 +150,63 @@ jobs:
   docker:
     name: Docker
     needs: [testing, create_release]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+            suffix: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            suffix: arm64
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v6
-      with:
-        go-version: 'stable'
-      id: go
-
-    - name: Check out code into the Go module directory
+    - name: Check out code
       uses: actions/checkout@v6
 
-    - name: Install
-      run: make install
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
-    - name: Docker
-      if: runner.os == 'Linux'
-      run: make docker
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Docker Push
-      if: runner.os == 'Linux'
-      run: |+
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          make docker-push
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Extract version
+      id: version
+      run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        platforms: ${{ matrix.platform }}
+        push: true
+        tags: moov/achgateway:${{ steps.version.outputs.VERSION }}-${{ matrix.suffix }}
+        build-args: VERSION=${{ steps.version.outputs.VERSION }}
+
+  docker-manifest:
+    name: Docker Manifest
+    needs: [docker]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Extract version
+      id: version
+      run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+    - name: Create and push manifest
+      run: |
+        docker buildx imagetools create -t moov/achgateway:${{ steps.version.outputs.VERSION }} \
+          moov/achgateway:${{ steps.version.outputs.VERSION }}-amd64 \
+          moov/achgateway:${{ steps.version.outputs.VERSION }}-arm64
+        docker buildx imagetools create -t moov/achgateway:latest \
+          moov/achgateway:${{ steps.version.outputs.VERSION }}-amd64 \
+          moov/achgateway:${{ steps.version.outputs.VERSION }}-arm64

--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,8 @@ else
 	CGO_ENABLED=1 GOOS=$(PLATFORM) go build -o bin/achgateway-$(PLATFORM)-amd64 cmd/achgateway/*
 endif
 
-dist-arm64: clean
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod=vendor -ldflags "-X github.com/moov-io/achgateway.Version=${VERSION}" -o bin/achgateway-linux-arm64 ./cmd/achgateway/
+dist-arm64: update clean
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod=vendor -ldflags "-X github.com/moov-io/achgateway.Version=${VERSION}" -o bin/achgateway-linux-arm64 github.com/moov-io/achgateway/cmd/achgateway
 
 docker-multiarch: update
-	docker buildx build --platform linux/amd64,linux/arm64 --build-arg VERSION=${VERSION} -t moov/achgateway:${VERSION} -f Dockerfile .
+	docker buildx build --pull --platform linux/amd64,linux/arm64 --build-arg VERSION=${VERSION} -t moov/achgateway:${VERSION} -t moov/achgateway:latest -f Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -99,3 +99,9 @@ ifeq ($(OS),Windows_NT)
 else
 	CGO_ENABLED=1 GOOS=$(PLATFORM) go build -o bin/achgateway-$(PLATFORM)-amd64 cmd/achgateway/*
 endif
+
+dist-arm64: clean
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod=vendor -ldflags "-X github.com/moov-io/achgateway.Version=${VERSION}" -o bin/achgateway-linux-arm64 ./cmd/achgateway/
+
+docker-multiarch: update
+	docker buildx build --platform linux/amd64,linux/arm64 --build-arg VERSION=${VERSION} -t moov/achgateway:${VERSION} -f Dockerfile .


### PR DESCRIPTION
# Changes
 - Add ARM64 binary to release artifacts (cross-compiled with CGO_ENABLED=0)
  - Replace single Docker job with matrix build using native ARM64 runners (ubuntu-24.04-arm)
  - Add docker-manifest job to create multi-arch Docker images
  - Add `dist-arm64` and `docker-multiarch` Makefile targets 
# Why Are Changes Being Made
Adds ARM64 support as requested by @adamdecaf  in #159. Uses GitHub's native ARM64 runners for fast builds instead of slow QEMU emulation.