### PR TITLE
chore: migrate Renovate config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "groupName": "all",
   "packageRules": [


### PR DESCRIPTION
Updates Renovate from the deprecated `config:base` preset to `config:recommended`.

This is the migration Renovate flags in the Dependency Dashboard (#245). No package versions or other Renovate settings are changed.