### PR TITLE
incoming: return nextCutoff when a file is queued

### DIFF
--- a/docs/concepts/submission.md
+++ b/docs/concepts/submission.md
@@ -36,6 +36,20 @@ POST /shards/{shardKey}/files/{fileID}
 
 The request body may be a [Nacha formatted](https://github.com/moov-io/ach/blob/master/test/testdata/ppd-debit.ach) file or the [moov-io/ach JSON representation](https://github.com/moov-io/ach/blob/master/test/testdata/ppd-valid.json). The incoming file must pass Nacha validation rules enforced by the moov-io/ach library.
 
+A successful HTTP response is JSON and includes the predicted next automated cutoff when it can be computed:
+
+```
+{
+  "id": "uuid",
+  "shardKey": "uuid",
+  "error": "",
+  "nextCutoff": "2025-01-07T16:15:00-05:00",
+  "acceptedAt": "2025-01-07T18:37:00Z"
+}
+```
+
+`nextCutoff` is optional. Existing clients that only read `id`, `shardKey`, and `error` can ignore the new fields. The timestamp is the next configured window for that shard after the file is accepted, using `Cutoffs.On` (`banking-days` by default, or `all-days`). Weekends never have an automated cutoff. A later [manual trigger](../../ops/cutoffs/#manual-triggers) can still upload the file earlier.
+
 ### Stream
 
 ACHGateway can accept files over a "stream" implementation supported by `gocloud.dev/pubsub`. The most common implementation is Kafka and the event format is JSON described by the [`models` package provided with ACHGateway](https://pkg.go.dev/github.com/moov-io/achgateway/pkg/models).

--- a/docs/ops/cutoffs.md
+++ b/docs/ops/cutoffs.md
@@ -17,6 +17,15 @@ Example with 30-min ODFI deadline
 | Same-Day | 2:15pm ET | 2:45pm ET | 4:00pm ET | 5:00pm ET |
 | Future Date | 4:15pm ET | 4:45pm ET | 5:30 pm ET | 8:30 am ET (Next Day) |
 
+## Next cutoff
+
+When a file is queued, ACHGateway predicts the next automated cutoff that should upload it and returns that time as `nextCutoff` on the HTTP queue response. The prediction uses the shard's `Cutoffs.Timezone`, `Windows`, and `On` setting:
+
+- `On: banking-days` (default) skips weekends and Federal Reserve holidays
+- `On: all-days` includes holidays but still skips weekends, matching automated processing
+
+A file queued at an exact window time is scheduled for a later window that day, or the first window on the next processing day. Manual [`/trigger-cutoff`](#manual-triggers) processing can still upload the file earlier than `nextCutoff`.
+
 ## Developers
 
 Moov publishes [a `Time` object in moov-io/base](https://pkg.go.dev/github.com/moov-io/base?utm_source=godoc#Time) to assist with calculating banking days and when holidays are observed. There is also a [`bankcron` Docker image](https://github.com/moov-io/bankcron) for running tasks only on banking days.

--- a/internal/incoming/models.go
+++ b/internal/incoming/models.go
@@ -19,6 +19,7 @@ package incoming
 
 import (
 	"errors"
+	"time"
 
 	"github.com/moov-io/ach"
 )
@@ -46,6 +47,12 @@ type QueueACHFileResponse struct {
 	FileID   string `json:"id"`
 	ShardKey string `json:"shardKey"`
 	Error    string `json:"error"`
+
+	// NextCutoff is the next automated cutoff that should upload this file.
+	// It is omitted when the time cannot be predicted. Callers may still receive
+	// the file earlier via a manual cutoff trigger.
+	NextCutoff *time.Time `json:"nextCutoff,omitempty"`
+	AcceptedAt *time.Time `json:"acceptedAt,omitempty"`
 }
 
 type CancelACHFile struct {

--- a/internal/incoming/models_test.go
+++ b/internal/incoming/models_test.go
@@ -1,0 +1,56 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package incoming
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueueACHFileResponseJSON_OmitsOptionalTimes(t *testing.T) {
+	bs, err := json.Marshal(QueueACHFileResponse{
+		FileID:   "f1",
+		ShardKey: "s1",
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"id":"f1","shardKey":"s1","error":""}`, string(bs))
+}
+
+func TestQueueACHFileResponseJSON_IncludesOptionalTimes(t *testing.T) {
+	next := time.Date(2025, time.January, 7, 16, 15, 0, 0, time.FixedZone("EST", -5*3600))
+	accepted := time.Date(2025, time.January, 7, 18, 37, 0, 0, time.UTC)
+
+	bs, err := json.Marshal(QueueACHFileResponse{
+		FileID:     "f1",
+		ShardKey:   "s1",
+		NextCutoff: &next,
+		AcceptedAt: &accepted,
+	})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(bs, &decoded))
+	require.Equal(t, "f1", decoded["id"])
+	require.Equal(t, "s1", decoded["shardKey"])
+	require.Equal(t, "", decoded["error"])
+	require.Equal(t, "2025-01-07T16:15:00-05:00", decoded["nextCutoff"])
+	require.Equal(t, "2025-01-07T18:37:00Z", decoded["acceptedAt"])
+}

--- a/internal/incoming/web/api_files_test.go
+++ b/internal/incoming/web/api_files_test.go
@@ -52,8 +52,13 @@ func TestCreateFileHandler(t *testing.T) {
 	go func() {
 		time.Sleep(time.Second)
 
+		next := time.Date(2025, time.January, 7, 16, 15, 0, 0, time.UTC)
+		accepted := time.Date(2025, time.January, 7, 13, 37, 0, 0, time.UTC)
 		queueFileResponses <- incoming.QueueACHFileResponse{
-			FileID: "f1",
+			FileID:     "f1",
+			ShardKey:   "s1",
+			NextCutoff: &next,
+			AcceptedAt: &accepted,
 		}
 	}()
 
@@ -81,6 +86,16 @@ func TestCreateFileHandler(t *testing.T) {
 	validateOpts := file.File.GetValidation()
 	require.NotNil(t, validateOpts)
 	require.True(t, validateOpts.PreserveSpaces)
+
+	var resp models.QueueACHFileResponse
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.Equal(t, "f1", resp.FileID)
+	require.Equal(t, "s1", resp.ShardKey)
+	require.NotNil(t, resp.NextCutoff)
+	require.Equal(t, "2025-01-07T16:15:00Z", resp.NextCutoff.UTC().Format(time.RFC3339))
+	require.NotNil(t, resp.AcceptedAt)
+	require.Equal(t, "2025-01-07T13:37:00Z", resp.AcceptedAt.UTC().Format(time.RFC3339))
 }
 
 func TestCreateFileHandler_Error(t *testing.T) {

--- a/internal/pipeline/aggregate.go
+++ b/internal/pipeline/aggregate.go
@@ -189,15 +189,29 @@ func (xfagg *aggregator) Shutdown() {
 func (xfagg *aggregator) acceptFile(ctx context.Context, msg incoming.ACHFile) (incoming.QueueACHFileResponse, error) {
 	err := xfagg.merger.HandleXfer(ctx, msg)
 
+	now := time.Now().In(time.UTC)
 	resp := incoming.QueueACHFileResponse{
-		FileID:   msg.FileID,
-		ShardKey: msg.ShardKey,
+		FileID:     msg.FileID,
+		ShardKey:   msg.ShardKey,
+		AcceptedAt: &now,
 	}
 	if err != nil {
 		resp.Error = err.Error()
+		return resp, err
 	}
 
-	return resp, err
+	nextCutoff, cutoffErr := schedule.NextCutoff(xfagg.shard.Cutoffs.Timezone, xfagg.shard.Cutoffs.Windows, xfagg.shard.Cutoffs.On, now)
+	if cutoffErr != nil {
+		xfagg.logger.Warn().With(log.Fields{
+			"fileID":   log.String(msg.FileID),
+			"shard":    log.String(xfagg.shard.Name),
+			"shardKey": log.String(msg.ShardKey),
+		}).Logf("unable to predict next cutoff: %v", cutoffErr)
+	} else if !nextCutoff.IsZero() {
+		resp.NextCutoff = &nextCutoff
+	}
+
+	return resp, nil
 }
 
 func (xfagg *aggregator) cancelFile(ctx context.Context, msg incoming.CancelACHFile) (models.FileCancellationResponse, error) {

--- a/internal/pipeline/aggregate_test.go
+++ b/internal/pipeline/aggregate_test.go
@@ -82,9 +82,60 @@ func TestAggregateACHFile(t *testing.T) {
 	require.Equal(t, "ppd-file1", response.FileID)
 	require.Equal(t, "test", response.ShardKey)
 	require.Empty(t, response.Error)
+	require.NotNil(t, response.AcceptedAt)
+	require.False(t, response.AcceptedAt.IsZero())
+	require.NotNil(t, response.NextCutoff)
+	require.False(t, response.NextCutoff.IsZero())
+
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	require.NoError(t, err)
+	require.Equal(t, "10:30", response.NextCutoff.In(loc).Format("15:04"))
 
 	require.NotNil(t, merge.LatestFile)
 	require.Equal(t, "ppd-file1", merge.LatestFile.FileID)
+}
+
+func TestAggregateACHFile_HandleXferError(t *testing.T) {
+	shard := service.Shard{
+		Name: "test",
+		Cutoffs: service.Cutoffs{
+			Timezone: "America/Los_Angeles",
+			Windows:  []string{"10:30"},
+		},
+		UploadAgent: "ftp-live",
+	}
+	uploadAgents := service.UploadAgents{
+		Agents: []service.UploadAgent{
+			{
+				ID:   "ftp-live",
+				Mock: &service.MockAgent{},
+				Paths: service.UploadPaths{
+					Outbound: "/outbound",
+				},
+			},
+		},
+		DefaultAgentID: "ftp-live",
+	}
+	var errorAlerting service.ErrorAlerting
+
+	xfagg, err := newAggregator(log.NewTestLogger(), &events.MockEmitter{}, shard, uploadAgents, errorAlerting)
+	require.NoError(t, err)
+
+	merge := &MockXferMerging{Err: errors.New("disk full")}
+	xfagg.merger = merge
+
+	file, err := ach.ReadFile(filepath.Join("..", "..", "testdata", "ppd-debit.ach"))
+	require.NoError(t, err)
+
+	response, err := xfagg.acceptFile(context.Background(), incoming.ACHFile{
+		FileID:   "ppd-file1",
+		ShardKey: "test",
+		File:     file,
+	})
+	require.EqualError(t, err, "disk full")
+	require.Equal(t, "disk full", response.Error)
+	require.NotNil(t, response.AcceptedAt)
+	require.Nil(t, response.NextCutoff)
 }
 
 func TestAggregate_notifyAfterUpload(t *testing.T) {

--- a/internal/schedule/next.go
+++ b/internal/schedule/next.go
@@ -1,0 +1,91 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package schedule
+
+import (
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/moov-io/base"
+)
+
+// NextCutoff returns the next automated cutoff that should upload a file queued at now.
+//
+// Predictions follow the same rules as automated cutoff processing:
+//   - Windows are compared in timezone as HH:MM.
+//   - A file queued at an exact window time is scheduled for a later window.
+//   - on == "all-days" includes holidays and still skips weekends
+//     (the scheduler never ticks on Saturday/Sunday).
+//   - Any other on value (including the default) uses banking days.
+//
+// An empty windows list returns a zero time. Invalid timezone or window values return an error.
+func NextCutoff(timezone string, windows []string, on string, now time.Time) (time.Time, error) {
+	if len(windows) == 0 {
+		return time.Time{}, nil
+	}
+
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("loading %s failed: %w", timezone, err)
+	}
+
+	cutoffs := copysort(windows)
+	dt := base.NewTime(now.In(loc))
+
+	if isProcessingDay(on, dt) {
+		nowHHMM := dt.Format("15:04")
+		for _, ct := range cutoffs {
+			if nowHHMM < ct {
+				return adjustNowToCutoff(ct, dt.Time, loc)
+			}
+		}
+	}
+
+	next, err := nextProcessingDay(on, dt)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return adjustNowToCutoff(cutoffs[0], next.Time, loc)
+}
+
+func isProcessingDay(on string, dt base.Time) bool {
+	if on == "all-days" {
+		return !dt.IsWeekend()
+	}
+	return dt.IsBankingDay()
+}
+
+func nextProcessingDay(on string, dt base.Time) (base.Time, error) {
+	if on != "all-days" {
+		return dt.AddBankingDay(1), nil
+	}
+
+	// Weekends never fire automated cutoffs, even when On=all-days.
+	for i := 0; i < 7; i++ {
+		dt = base.NewTime(dt.Time.AddDate(0, 0, 1))
+		if !dt.IsWeekend() {
+			return dt, nil
+		}
+	}
+	return base.Time{}, fmt.Errorf("unable to find next cutoff after %s", dt.Format(time.RFC3339))
+}
+
+func adjustNowToCutoff(cutoff string, now time.Time, loc *time.Location) (time.Time, error) {
+	c, err := time.Parse("15:04", cutoff)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parsing %s failed: %w", cutoff, err)
+	}
+
+	out := now.In(loc)
+	return time.Date(out.Year(), out.Month(), out.Day(), c.Hour(), c.Minute(), 0, 0, out.Location()), nil
+}
+
+func copysort(input []string) []string {
+	out := make([]string, len(input))
+	copy(out, input)
+	slices.Sort(out)
+	return out
+}

--- a/internal/schedule/next_test.go
+++ b/internal/schedule/next_test.go
@@ -1,0 +1,155 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package schedule
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNextCutoff(t *testing.T) {
+	type check struct {
+		now      time.Time
+		expected time.Time
+	}
+
+	eastern, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	central, err := time.LoadLocation("America/Chicago")
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		timezone string
+		windows  []string
+		on       string
+		checks   []check
+	}{
+		{
+			name:     "banking-days",
+			timezone: "America/New_York",
+			windows:  []string{"10:00", "14:15", "16:15"},
+			checks: []check{
+				{
+					// before 16:15 cutoff
+					now:      time.Date(2025, time.January, 7, 13, 37, 0, 0, central),
+					expected: time.Date(2025, time.January, 7, 16, 15, 0, 0, eastern),
+				},
+				{
+					// exactly 14:15 ET rolls to the later window
+					now:      time.Date(2025, time.January, 7, 13, 15, 0, 0, central),
+					expected: time.Date(2025, time.January, 7, 16, 15, 0, 0, eastern),
+				},
+				{
+					// before first cutoff
+					now:      time.Date(2025, time.January, 7, 8, 37, 0, 0, central),
+					expected: time.Date(2025, time.January, 7, 10, 0, 0, 0, eastern),
+				},
+				{
+					// after last cutoff
+					now:      time.Date(2025, time.January, 7, 16, 16, 0, 0, central),
+					expected: time.Date(2025, time.January, 8, 10, 0, 0, 0, eastern),
+				},
+			},
+		},
+		{
+			name:     "weekend-to-monday",
+			timezone: "America/New_York",
+			windows:  []string{"17:30"},
+			checks: []check{
+				{
+					now:      time.Date(2025, time.September, 6, 2, 0, 35, 0, central),
+					expected: time.Date(2025, time.September, 8, 17, 30, 0, 0, eastern),
+				},
+				{
+					now:      time.Date(2025, time.September, 6, 18, 16, 0, 0, central),
+					expected: time.Date(2025, time.September, 8, 17, 30, 0, 0, eastern),
+				},
+			},
+		},
+		{
+			name:     "holiday-banking-days",
+			timezone: "America/New_York",
+			windows:  []string{"15:30"},
+			checks: []check{
+				{
+					// Monday July 4 2022 is Independence Day
+					now:      time.Date(2022, time.July, 4, 10, 0, 0, 0, eastern),
+					expected: time.Date(2022, time.July, 5, 15, 30, 0, 0, eastern),
+				},
+			},
+		},
+		{
+			name:     "holiday-all-days",
+			timezone: "America/New_York",
+			windows:  []string{"15:30"},
+			on:       "all-days",
+			checks: []check{
+				{
+					now:      time.Date(2022, time.July, 4, 10, 0, 0, 0, eastern),
+					expected: time.Date(2022, time.July, 4, 15, 30, 0, 0, eastern),
+				},
+			},
+		},
+		{
+			name:     "friday-into-labor-day-banking-days",
+			timezone: "America/New_York",
+			windows:  []string{"17:30"},
+			checks: []check{
+				{
+					// Friday after last window, Monday is Labor Day 2025
+					now:      time.Date(2025, time.August, 29, 18, 0, 0, 0, eastern),
+					expected: time.Date(2025, time.September, 2, 17, 30, 0, 0, eastern),
+				},
+			},
+		},
+		{
+			name:     "friday-into-labor-day-all-days",
+			timezone: "America/New_York",
+			windows:  []string{"17:30"},
+			on:       "all-days",
+			checks: []check{
+				{
+					// Weekends still do not process; Labor Day Monday does
+					now:      time.Date(2025, time.August, 29, 18, 0, 0, 0, eastern),
+					expected: time.Date(2025, time.September, 1, 17, 30, 0, 0, eastern),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for idx, chk := range tc.checks {
+				got, err := NextCutoff(tc.timezone, tc.windows, tc.on, chk.now)
+				require.NoError(t, err)
+
+				expected := chk.expected.Format(time.RFC3339)
+				desc := fmt.Sprintf("checks[%d] windows=%s now=%s", idx, strings.Join(tc.windows, ","), chk.now.Format(time.RFC3339))
+				require.Equal(t, expected, got.Format(time.RFC3339), desc)
+			}
+		})
+	}
+}
+
+func TestNextCutoff_EmptyWindows(t *testing.T) {
+	got, err := NextCutoff("America/New_York", nil, "", time.Now())
+	require.NoError(t, err)
+	require.True(t, got.IsZero())
+}
+
+func TestNextCutoff_InvalidTimezone(t *testing.T) {
+	_, err := NextCutoff("not/a/zone", []string{"10:00"}, "", time.Now())
+	require.Error(t, err)
+}
+
+func TestNextCutoff_InvalidWindow(t *testing.T) {
+	_, err := NextCutoff("America/New_York", []string{"noon"}, "", time.Date(2025, time.January, 7, 9, 0, 0, 0, time.UTC))
+	require.Error(t, err)
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -77,7 +77,11 @@ paths:
               $ref: 'https://raw.githubusercontent.com/moov-io/ach/master/openapi.yaml#/components/schemas/CreateFile'
       responses:
         '200':
-          description: File accepted successfully without errors.
+          description: File accepted. The response includes the predicted next automated cutoff when it can be computed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueueACHFileResponse'
         '400':
           description: Unable to read file, make sure the file is in either valid Nacha or moov-io/ach formatting.
         '500':
@@ -472,3 +476,27 @@ components:
           example:
             "testing": "ERROR processing shard: hostname not found"
             "SD-live": null
+
+    QueueACHFileResponse:
+      description: |
+        Acknowledgement that a file was queued for a later cutoff. Existing clients can keep reading `id`, `shardKey`, and `error`.
+        `nextCutoff` is the next automated window that should upload the file. It is omitted when the time cannot be predicted.
+        A later manual `/trigger-cutoff` can still upload the file earlier.
+      properties:
+        id:
+          type: string
+          example: AE694B55-C103-4FA5-B62E-E4F6F79AD581
+        shardKey:
+          type: string
+          example: testing
+        error:
+          type: string
+          example: ""
+        nextCutoff:
+          type: string
+          format: date-time
+          example: "2025-01-07T16:15:00-05:00"
+        acceptedAt:
+          type: string
+          format: date-time
+          example: "2025-01-07T13:37:00Z"

--- a/pkg/models/events.go
+++ b/pkg/models/events.go
@@ -272,6 +272,7 @@ func (evt *QueueACHFile) SetValidation(opts *ach.ValidateOpts) {
 }
 
 // QueueACHFileResponse is a response to the QueueACHFile event signaling if the file was successfully enqueued.
+// NextCutoff is the next automated cutoff that should upload the file and is omitted when it cannot be predicted.
 type QueueACHFileResponse incoming.QueueACHFileResponse
 
 // InvalidQueueFile is an event that achgateway produces when a QueueACHFile could not be processed.


### PR DESCRIPTION
## What

When a file is queued, ACHGateway now predicts the next automated cutoff that should upload it and returns that time on the existing queue acknowledgement.

`POST /shards/{shardKey}/files/{fileID}` still returns HTTP 200 with `id`, `shardKey`, and `error`. The response may also include:

- `nextCutoff`: the next configured window after acceptance
- `acceptedAt`: when the file was accepted

Both fields are omitted when they are not available. Existing clients that only read the original keys do not need to change.

## How nextCutoff is computed

The prediction uses the shard's `Cutoffs.Timezone`, `Windows`, and `On`:

- `On: banking-days` (default) skips weekends and Federal Reserve holidays
- `On: all-days` includes holidays but still skips weekends, matching automated processing
- A file queued at an exact window time is scheduled for a later window that day, or the first window on the next processing day
- A later manual `/trigger-cutoff` can still upload the file earlier
- A prediction failure is logged and does not fail the enqueue

## Compatibility

- No config, event type, or request-body changes
- Existing JSON keys keep the same names and values
- New fields use `omitempty`

## Test plan

- [x] Unit tests for banking days, holidays, weekends, and `all-days`
- [x] Queue acknowledgement JSON still encodes `id`/`shardKey`/`error` when the new fields are absent
- [x] `acceptFile` includes `nextCutoff` on success and still returns the original error on merge failure
- [x] `go test ./internal/schedule/ ./internal/incoming/ ./internal/incoming/web/ ./internal/pipeline/ ./pkg/models/ ./internal/service/`