### PR TITLE
build: publish linux/arm64 binaries and Docker images

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -60,8 +60,16 @@ jobs:
       run: bash <(curl -s https://codecov.io/bash)
 
   docker:
-    name: Docker Build
-    runs-on: ubuntu-latest
+    name: Docker Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
@@ -78,5 +86,4 @@ jobs:
       run: make install
 
     - name: Docker Build
-      if: runner.os == 'Linux'
-      run: make dev-docker
+      run: make docker-build-arch ARCH=${{ matrix.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+            asset: achgateway-linux-amd64
+          - os: ubuntu-latest
+            arch: arm64
+            asset: achgateway-linux-arm64
+          - os: macos-latest
+            arch: arm64
+            asset: achgateway-darwin-arm64
+          - os: macos-latest
+            arch: amd64
+            asset: achgateway-darwin-amd64
+          - os: windows-latest
+            arch: amd64
+            asset: achgateway.exe
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
@@ -87,7 +102,7 @@ jobs:
       run: make install
 
     - name: Distribute
-      run: make dist
+      run: make dist ARCH=${{ matrix.arch }}
 
     - name: Get Release File Name & Upload URL
       id: get_release_info
@@ -99,43 +114,28 @@ jobs:
         TAG_REF_NAME: ${{ github.ref }}
         REPOSITORY_NAME: ${{ github.repository }}
 
-    - name: Upload Linux Binary
-      if: runner.os == 'Linux'
+    - name: Upload Binary
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-        asset_path: ./bin/achgateway-linux-amd64
-        asset_name: achgateway-linux-amd64
-        asset_content_type: application/octet-stream
-
-    - name: Upload macOS Binary
-      if: runner.os == 'macOS'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-        asset_path: ./bin/achgateway-darwin-amd64
-        asset_name: achgateway-darwin-amd64
-        asset_content_type: application/octet-stream
-
-    - name: Upload Windows Binary
-      if: runner.os == 'Windows'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-        asset_path: ./bin/achgateway.exe
-        asset_name: achgateway.exe
+        asset_path: ./bin/${{ matrix.asset }}
+        asset_name: ${{ matrix.asset }}
         asset_content_type: application/octet-stream
 
   docker:
-    name: Docker
+    name: Docker ${{ matrix.arch }}
     needs: [testing, create_release]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
@@ -149,15 +149,30 @@ jobs:
     - name: Install
       run: make install
 
-    - name: Docker
-      if: runner.os == 'Linux'
-      run: make docker
-
-    - name: Docker Push
-      if: runner.os == 'Linux'
-      run: |+
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          make docker-push
+    - name: Login to Docker Hub
+      run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build and push image
+      run: |
+        make docker-build-arch ARCH=${{ matrix.arch }}
+        make docker-push-arch ARCH=${{ matrix.arch }}
+
+  docker-manifest:
+    name: Docker Manifest
+    needs: [docker]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+
+    - name: Login to Docker Hub
+      run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Create and push manifests
+      run: make docker-manifest

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # generated-from:8ef700b33a05ab58ec9e7fd3ad1a0d8a99a742beeefc09d26bc7e4b6dd2ad699 DO NOT REMOVE, DO UPDATE
 
 PLATFORM=$(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH ?= $(shell go env GOARCH)
 PWD := $(shell pwd)
 
 ifndef VERSION
@@ -56,6 +57,22 @@ docker-push:
 	docker push moov/achgateway:${VERSION}
 	docker push moov/achgateway:latest
 
+# Native per-arch image used by release.yml. Run on an amd64 or arm64 host
+# (or pass --platform via DOCKER_DEFAULT_PLATFORM) so the Dockerfile builds
+# without QEMU. Example: make docker-build-arch ARCH=arm64
+.PHONY: docker-build-arch docker-push-arch docker-manifest
+docker-build-arch: update
+	docker build --pull --platform linux/$(ARCH) --build-arg VERSION=${VERSION} -t moov/achgateway:${VERSION}-$(ARCH) -f Dockerfile .
+
+docker-push-arch:
+	docker push moov/achgateway:${VERSION}-$(ARCH)
+
+docker-manifest:
+	docker manifest create moov/achgateway:${VERSION} moov/achgateway:${VERSION}-amd64 moov/achgateway:${VERSION}-arm64
+	docker manifest push moov/achgateway:${VERSION}
+	docker manifest create moov/achgateway:latest moov/achgateway:${VERSION}-amd64 moov/achgateway:${VERSION}-arm64
+	docker manifest push moov/achgateway:latest
+
 .PHONY: dev-docker
 dev-docker: update
 	docker build --pull --build-arg VERSION=${DEV_VERSION} -t moov/achgateway:${DEV_VERSION} -f Dockerfile .
@@ -93,9 +110,13 @@ AUTHORS:
 	@$(file >>$@,# For how it is generated, see `make AUTHORS`.)
 	@echo "$(shell git log --format='\n%aN <%aE>' | LC_ALL=C.UTF-8 sort -uf)" >> $@
 
-dist: clean build
+# Cross-compile is safe: this module does not use cgo. Override ARCH to
+# produce another architecture, e.g. make dist ARCH=arm64
+.PHONY: dist
+dist: update
+	@mkdir -p bin
 ifeq ($(OS),Windows_NT)
-	CGO_ENABLED=1 GOOS=windows go build -o bin/achgateway.exe cmd/achgateway/*
+	CGO_ENABLED=0 GOOS=windows GOARCH=$(ARCH) go build -mod=vendor -ldflags "-X github.com/moov-io/achgateway.Version=${VERSION}" -o bin/achgateway.exe github.com/moov-io/achgateway/cmd/achgateway
 else
-	CGO_ENABLED=1 GOOS=$(PLATFORM) go build -o bin/achgateway-$(PLATFORM)-amd64 cmd/achgateway/*
+	CGO_ENABLED=0 GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -mod=vendor -ldflags "-X github.com/moov-io/achgateway.Version=${VERSION}" -o bin/achgateway-$(PLATFORM)-$(ARCH) github.com/moov-io/achgateway/cmd/achgateway
 endif

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you believe you have identified a security vulnerability please responsibly r
 
 Read through the [project docs](https://moov-io.github.io/achgateway/) to gain an understanding of this project's purpose and how to run it.
 
-We publish a [public Docker image `moov/achgateway`](https://hub.docker.com/r/moov/achgateway/) from Docker Hub or use this repository. No configuration is required to serve on `:8484` and metrics at `:9494/metrics` in Prometheus format.
+We publish a [public Docker image `moov/achgateway`](https://hub.docker.com/r/moov/achgateway/) from Docker Hub (`linux/amd64` and `linux/arm64`) or use this repository. No configuration is required to serve on `:8484` and metrics at `:9494/metrics` in Prometheus format.
 
 Start achgateway and an FTP server:
 ```

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -8,7 +8,7 @@ menubar: docs-menu
 
 # Docker
 
-You can download a [docker image called `moov/achgateway`](https://hub.docker.com/r/moov/achgateway/) from Docker Hub or use this repository. However it's recommended to [download the code repository](https://github.com/moov-io/achgateway) and running `docker compose up` in the root directory.
+You can download a [docker image called `moov/achgateway`](https://hub.docker.com/r/moov/achgateway/) from Docker Hub or use this repository. Release images are published for `linux/amd64` and `linux/arm64`. However it's recommended to [download the code repository](https://github.com/moov-io/achgateway) and running `docker compose up` in the root directory.
 
 ```
 # Inside of ./examples/getting-started/


### PR DESCRIPTION
Closes #159. Reimplements #307.

#307 added ARM64 release artifacts, but it is stale against current master and rewrote the Docker job around QEMU/`docker/build-push-action`. That is slower and harder to test locally than the pattern we already use in `moov-io/ach`.

This PR keeps the existing Makefile/Dockerfile and adds the same native-runner flow:

- `make dist ARCH=arm64` (or `amd64`) for release binaries. The module does not use cgo, so cross-compiling from the Linux/macOS publish jobs is safe.
- Publish `achgateway-linux-arm64` and `achgateway-darwin-arm64` alongside the existing amd64/Windows assets.
- `make docker-build-arch ARCH=arm64` on `ubuntu-24.04-arm` (and amd64 on `ubuntu-latest`) so each image is built natively, then `make docker-manifest` publishes `moov/achgateway:$VERSION` and `:latest` as a multi-arch list.
- PR CI now builds both Docker arches so the ARM path is exercised before a tag.

Verified locally: `make dist ARCH=amd64` / `ARCH=arm64` produced darwin binaries of the right Mach-O types; linux amd64/arm64 cross-builds produced ELF x86-64 and aarch64; `make docker-build-arch ARCH=arm64` built `moov/achgateway:v0.36.2-arm64`.