### PR TITLE
audittrail: skip wrapping files already encrypted to the configured key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Please refer to the [Github Releases](https://github.com/moov-io/achgateway/releases) page for future updates.
 
+BUG FIXES
+
+- audittrail: do not wrap files already encrypted to the configured GPG key
+
 IMPROVEMENTS
 
 - pipeline: never abort a cutoff early on a per-file flatten/upload error; remaining files still upload

--- a/internal/audittrail/storage_blob.go
+++ b/internal/audittrail/storage_blob.go
@@ -5,14 +5,19 @@
 package audittrail
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 
+	"github.com/moov-io/achgateway/internal/gpgx"
 	"github.com/moov-io/achgateway/internal/service"
 	"github.com/moov-io/base/telemetry"
 	"github.com/moov-io/cryptfs"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -30,6 +35,7 @@ type blobStorage struct {
 	id      string
 	bucket  *blob.Bucket
 	cryptor *cryptfs.FS
+	gpgKeys openpgp.EntityList
 }
 
 func newBlobStorage(cfg *service.AuditTrail) (*blobStorage, error) {
@@ -45,6 +51,10 @@ func newBlobStorage(cfg *service.AuditTrail) (*blobStorage, error) {
 
 	if cfg.GPG != nil {
 		storage.cryptor, err = cryptfs.FromCryptor(cryptfs.NewGPGEncryptorFile(cfg.GPG.KeyFile))
+		if err != nil {
+			return nil, err
+		}
+		storage.gpgKeys, err = gpgx.ReadArmoredKeyFile(cfg.GPG.KeyFile)
 		if err != nil {
 			return nil, err
 		}
@@ -73,7 +83,9 @@ func (bs *blobStorage) SaveFile(ctx context.Context, path string, data []byte) e
 
 	var encrypted []byte
 	var err error
-	if bs.cryptor != nil {
+	// Always encrypt with the configured audittrail key, unless the
+	// payload is already encrypted to that same key.
+	if bs.cryptor != nil && !alreadyEncryptedTo(data, bs.gpgKeys) {
 		encrypted, err = bs.cryptor.Disfigure(data)
 	} else {
 		encrypted = data
@@ -123,4 +135,69 @@ func (bs *blobStorage) GetFile(ctx context.Context, path string) (io.ReadCloser,
 		return nil, fmt.Errorf("get file: %v", err)
 	}
 	return r, nil
+}
+
+func alreadyEncryptedTo(data []byte, keys openpgp.EntityList) bool {
+	if len(keys) == 0 {
+		return false
+	}
+	recipients, err := encryptedToKeyIDs(data)
+	if err != nil || len(recipients) == 0 {
+		return false
+	}
+	ours := keyIDs(keys)
+	for _, recipient := range recipients {
+		if recipient == 0 {
+			continue
+		}
+		for _, oursID := range ours {
+			if recipient == oursID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func encryptedToKeyIDs(data []byte) ([]uint64, error) {
+	body := bytes.TrimSpace(data)
+	if !bytes.HasPrefix(body, []byte("-----BEGIN PGP ")) {
+		return nil, nil
+	}
+	block, err := armor.Decode(bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	packets := packet.NewReader(block.Body)
+	var ids []uint64
+	for {
+		p, err := packets.Next()
+		if err != nil {
+			if err == io.EOF {
+				return ids, nil
+			}
+			return ids, err
+		}
+		switch p := p.(type) {
+		case *packet.EncryptedKey:
+			ids = append(ids, p.KeyId)
+		case *packet.SymmetricallyEncrypted, *packet.AEADEncrypted:
+			return ids, nil
+		}
+	}
+}
+
+func keyIDs(keys openpgp.EntityList) []uint64 {
+	var ids []uint64
+	for _, entity := range keys {
+		if entity.PrimaryKey != nil {
+			ids = append(ids, entity.PrimaryKey.KeyId)
+		}
+		for i := range entity.Subkeys {
+			if entity.Subkeys[i].PublicKey != nil {
+				ids = append(ids, entity.Subkeys[i].PublicKey.KeyId)
+			}
+		}
+	}
+	return ids
 }

--- a/internal/audittrail/storage_blob_test.go
+++ b/internal/audittrail/storage_blob_test.go
@@ -8,11 +8,15 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/moov-io/achgateway/internal/service"
+	"github.com/moov-io/cryptfs"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,6 +51,70 @@ func TestBlobStorage(t *testing.T) {
 	}
 }
 
+func TestBlobStorage__AlreadyEncrypted(t *testing.T) {
+	cfg := &service.AuditTrail{
+		BucketURI: "mem://",
+		GPG: &service.GPG{
+			KeyFile: publicKeyPath,
+		},
+	}
+	store, err := newBlobStorage(cfg)
+	require.NoError(t, err)
+	defer store.Close()
+
+	plain := []byte("nacha formatted data")
+	require.NoError(t, store.SaveFile(context.Background(), "once.ach", plain))
+
+	r, err := store.GetFile(context.Background(), "once.ach")
+	require.NoError(t, err)
+	wrapped, err := io.ReadAll(r)
+	r.Close()
+	require.NoError(t, err)
+	require.Contains(t, string(wrapped), "BEGIN PGP MESSAGE")
+
+	// Saving a payload already encrypted to the audittrail key must not wrap again.
+	require.NoError(t, store.SaveFile(context.Background(), "twice.ach", wrapped))
+
+	r, err = store.GetFile(context.Background(), "twice.ach")
+	require.NoError(t, err)
+	defer r.Close()
+
+	stored, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, wrapped, stored)
+}
+
+func TestBlobStorage__OtherKeyStillEncrypted(t *testing.T) {
+	otherKey := writeTempPublicKey(t)
+	other, err := cryptfs.FromCryptor(cryptfs.NewGPGEncryptorFile(otherKey))
+	require.NoError(t, err)
+
+	foreign, err := other.Disfigure([]byte("nacha formatted data"))
+	require.NoError(t, err)
+	require.Contains(t, string(foreign), "BEGIN PGP MESSAGE")
+
+	cfg := &service.AuditTrail{
+		BucketURI: "mem://",
+		GPG: &service.GPG{
+			KeyFile: publicKeyPath,
+		},
+	}
+	store, err := newBlobStorage(cfg)
+	require.NoError(t, err)
+	defer store.Close()
+
+	require.NoError(t, store.SaveFile(context.Background(), "foreign.ach", foreign))
+
+	r, err := store.GetFile(context.Background(), "foreign.ach")
+	require.NoError(t, err)
+	defer r.Close()
+
+	stored, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Contains(t, string(stored), "BEGIN PGP MESSAGE")
+	require.NotEqual(t, foreign, stored)
+}
+
 func TestBlobStorage__NoGPG(t *testing.T) {
 	cfg := &service.AuditTrail{
 		BucketURI: "mem://",
@@ -76,4 +144,21 @@ func TestBlobStorageErr(t *testing.T) {
 	if _, err := NewStorage(cfg); err == nil {
 		t.Error("expected error")
 	}
+}
+
+func writeTempPublicKey(t *testing.T) string {
+	t.Helper()
+
+	entity, err := openpgp.NewEntity("other", "test", "other@example.com", nil)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	w, err := armor.Encode(&buf, openpgp.PublicKeyType, nil)
+	require.NoError(t, err)
+	require.NoError(t, entity.Serialize(w))
+	require.NoError(t, w.Close())
+
+	path := filepath.Join(t.TempDir(), "other.pub")
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0600))
+	return path
 }


### PR DESCRIPTION
# Changes

Incoming files (FedACH over Connect:Direct) can already be armored PGP to the audittrail public key. `SaveFile` always ran `Disfigure` when GPG was configured, so those objects were wrapped twice. A single unwrap then left another `-----BEGIN PGP MESSAGE-----`.

`SaveFile` still encrypts with the configured audittrail key. It only stores the payload as-is when it is already encrypted to that same key. A message encrypted to a different key is still wrapped.

# Why Are Changes Being Made

ach-web-viewer could list inbound FedACH ACK files but GET failed after one GPG unwrap. The same audittrail private key decrypted the object twice; the second unwrap was the ASCII ACK.

This stops new double wraps. Objects already stored with two layers are unchanged.