### PR TITLE
fix: jail filesystem writes to the storage root

### DIFF
--- a/internal/storage/filesystem.go
+++ b/internal/storage/filesystem.go
@@ -28,8 +28,16 @@ func NewFilesystem(root string) (Chest, error) {
 	}, nil
 }
 
+// invalidPath rejects the same escapes Open already blocked: parent
+// segments and absolute paths. filepath.Join treats an absolute element
+// as a new root, so WriteFile("/tmp/x") and WriteFile("../x") would
+// otherwise land outside f.root.
+func invalidPath(path string) bool {
+	return strings.Contains(path, "..") || strings.HasPrefix(path, "/")
+}
+
 func (f *filesystem) Open(path string) (fs.File, error) {
-	if strings.Contains(path, "..") || strings.HasPrefix(path, "/") {
+	if invalidPath(path) {
 		return nil, errors.New("invalid path")
 	}
 
@@ -63,6 +71,9 @@ const (
 )
 
 func (f *filesystem) Glob(pattern string) ([]FileStat, error) {
+	if invalidPath(pattern) {
+		return nil, errors.New("invalid path")
+	}
 	subdir, suffix := filepath.Split(pattern)
 	where := filepath.Join(f.root, subdir)
 
@@ -107,6 +118,9 @@ func (f *filesystem) Glob(pattern string) ([]FileStat, error) {
 }
 
 func (f *filesystem) ReplaceFile(oldpath, newpath string) error {
+	if invalidPath(oldpath) || invalidPath(newpath) {
+		return errors.New("invalid path")
+	}
 	oldpath = filepath.Join(f.root, oldpath)
 	newpath = filepath.Join(f.root, newpath)
 
@@ -126,6 +140,9 @@ func (f *filesystem) ReplaceFile(oldpath, newpath string) error {
 }
 
 func (f *filesystem) ReplaceDir(oldpath, newpath string) error {
+	if invalidPath(oldpath) || invalidPath(newpath) {
+		return errors.New("invalid path")
+	}
 	path := filepath.Join(f.root, oldpath)
 
 	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
@@ -138,14 +155,23 @@ func (f *filesystem) ReplaceDir(oldpath, newpath string) error {
 }
 
 func (f *filesystem) MkdirAll(path string) error {
+	if invalidPath(path) {
+		return errors.New("invalid path")
+	}
 	return os.MkdirAll(filepath.Join(f.root, path), 0750)
 }
 
 func (f *filesystem) RmdirAll(path string) error {
+	if invalidPath(path) {
+		return errors.New("invalid path")
+	}
 	return os.RemoveAll(filepath.Join(f.root, path))
 }
 
 func (f *filesystem) WriteFile(path string, contents []byte) error {
+	if invalidPath(path) {
+		return errors.New("invalid path")
+	}
 	dir, path := filepath.Split(path)
 	dir = filepath.Join(f.root, dir)
 

--- a/internal/storage/filesystem_test.go
+++ b/internal/storage/filesystem_test.go
@@ -24,6 +24,51 @@ func TestFilesystem(t *testing.T) {
 	require.Equal(t, "nacha", finalContents)
 }
 
+func TestFilesystemRejectsEscape(t *testing.T) {
+	dir := t.TempDir()
+	chest, err := NewFilesystem(dir)
+	require.NoError(t, err)
+
+	parentEscape := filepath.Join(filepath.Dir(dir), "achgateway-escaped.ach")
+	t.Cleanup(func() { os.Remove(parentEscape) })
+
+	err = chest.WriteFile("../achgateway-escaped.ach", []byte("pwn"))
+	require.EqualError(t, err, "invalid path")
+	_, err = os.Stat(parentEscape)
+	require.True(t, os.IsNotExist(err))
+
+	err = chest.WriteFile("/tmp/achgateway-escaped.ach", []byte("pwn"))
+	require.EqualError(t, err, "invalid path")
+
+	err = chest.RmdirAll("..")
+	require.EqualError(t, err, "invalid path")
+	_, err = os.Stat(dir)
+	require.NoError(t, err)
+
+	err = chest.MkdirAll("../outside")
+	require.EqualError(t, err, "invalid path")
+
+	err = chest.ReplaceFile("../old", "ok")
+	require.EqualError(t, err, "invalid path")
+	err = chest.ReplaceFile("ok", "../new")
+	require.EqualError(t, err, "invalid path")
+
+	err = chest.ReplaceDir("../old", "ok")
+	require.EqualError(t, err, "invalid path")
+
+	_, err = chest.Glob("../../*")
+	require.EqualError(t, err, "invalid path")
+
+	_, err = chest.Open("../secret")
+	require.EqualError(t, err, "invalid path")
+
+	err = chest.WriteFile("mergable/SD1/f1.ach", []byte("nacha"))
+	require.NoError(t, err)
+	file, err := chest.Open("mergable/SD1/f1.ach")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+}
+
 func setupFilesystemGlobTest(tb testing.TB, iterations int) (Chest, string, int) {
 	tb.Helper()
 


### PR DESCRIPTION
# Changes

`Open` already rejected paths with `..` or a leading `/`. `WriteFile`, `ReplaceFile`, `ReplaceDir`, `MkdirAll`, `RmdirAll`, and `Glob` joined the caller path onto the storage root with no check.

`filepath.Join` treats an absolute element as a new root, so `WriteFile("/tmp/x", ...)` and `WriteFile("../x", ...)` land outside the configured directory. Queue `FileID` is only checked non-empty, then `writeACHFile` joins it under `mergable/<shard>/`.

This extracts the existing `Open` check and applies it to the mutators. Relative paths used by merge and cleanup (`mergable/...`, `foo/bar.txt`) are unchanged.

@adamdecaf

# Why Are Changes Being Made

An attacker who can submit an ACH file (HTTP or queue) already chooses `FileID`. They do not already have write outside the storage root. That root jail is the remaining guard, and `Open` already encoded it.

`TestFilesystemRejectsEscape` fails if the `WriteFile` check is removed (parent write succeeds) and passes with it.