### PR TITLE
ci: skip CodeQL when GitHub cannot accept SARIF

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   CodeQL-Build:
+    if: ${{ !github.event.repository.private && !github.event.repository.archived }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
GitHub only accepts CodeQL SARIF uploads on public (non-archived) repositories, or private repositories with GitHub Advanced Security.

This skips the CodeQL job when `repository.private` or `repository.archived` is set, so CI does not fail on upload with "Advanced Security must be enabled" / "Code scanning is not enabled".