### PR TITLE
ci: skip code owners on lockfiles and workflows; automerge Renovate deps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,8 @@ go.mod
 go.sum
 **/go.mod
 **/go.sum
+Gemfile.lock
+**/Gemfile.lock
+
+# GitHub Actions workflows have no owners so action-only PRs skip code-owner review.
+.github/workflows/**

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,24 @@
         "major"
       ],
       "enabled": false
+    },
+    {
+      "description": "Automerge GitHub Actions updates (including majors)",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Keep docker/image majors out of grouped update-all PRs and do not automerge them",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "docker major",
+      "automerge": false
     }
   ],
   "platformAutomerge": true


### PR DESCRIPTION
Keep the catch-all CODEOWNERS entry. Lockfiles (`go.mod` / `go.sum` and others that exist) and `.github/workflows/**` are left without owners (last-match-wins) so dependency-only PRs do not request a code-owner review.

Renovate: automerge minor/patch/pin/digest and GitHub Actions updates (including action majors) with platformAutomerge. Docker/image majors are split into their own group and not auto-merged.