### PR TITLE
fix(pipeline): emit FileUploaded when merge rewrites batch headers

### DIFF
--- a/internal/pipeline/merging.go
+++ b/internal/pipeline/merging.go
@@ -27,6 +27,7 @@ import (
 	"maps"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -668,7 +669,7 @@ func (m *filesystemMerging) accumulateMappings(mappings entryFileMapping, seen m
 	//   - Same file_id already queued for this key → skip (idempotent re-queue /
 	//     duplicate rows in one file only need one FileUploaded for that file_id).
 	for i := range file.Batches {
-		bh := file.Batches[i].GetHeader().String()
+		bh := file.Batches[i].GetHeader()
 
 		entries := file.Batches[i].GetEntries()
 
@@ -735,21 +736,38 @@ func mappingLeftoverCount(mappings entryFileMapping) int {
 	return n
 }
 
-func makeKey(bh string, entry *ach.EntryDetail) string {
-	// Callers skip nil entries — do not return "" (would collide in the mapping).
-	//
-	// NACHA BatchHeader.String() is always 94 chars; we drop the trailing 7-char
-	// BatchNumber (merge renumbers batches). Preserve the historical
-	// fmt.Sprintf("%87.87s") contract: truncate long headers and left-pad short
-	// ones so keys stay stable if a non-standard header ever appears.
-	switch {
-	case len(bh) > 87:
-		bh = bh[:87]
-	case len(bh) < 87:
-		bh = strings.Repeat(" ", 87-len(bh)) + bh
+func makeKey(bh *ach.BatchHeader, entry *ach.EntryDetail) string {
+	// Callers skip nil entries. Do not return "" — that would collide in the mapping.
+	if entry == nil {
+		return "\x00nil-entry"
 	}
-	// Avoid fmt.Sprintf: concatenation is faster and allocates one string.
-	return bh + entry.String()
+
+	// MergeDir combines batches with BatchHeader.Equal, then copies entries under
+	// the first matching header. Equal ignores CompanyDiscretionaryData,
+	// CompanyDescriptiveDate, SettlementDate, OriginatorStatusCode, and company
+	// name case — all of which appear in BatchHeader.String()[:87] (and BatchNumber,
+	// which merge also rewrites). Keys built from the original 87-char header
+	// therefore miss after merge, so FileUploaded is not emitted for those inputs.
+	var b strings.Builder
+	if bh != nil {
+		b.Grow(96 + 94)
+		b.WriteString(strconv.Itoa(bh.ServiceClassCode))
+		b.WriteByte('|')
+		b.WriteString(strings.ToUpper(bh.CompanyName))
+		b.WriteByte('|')
+		b.WriteString(bh.CompanyIdentification)
+		b.WriteByte('|')
+		b.WriteString(bh.StandardEntryClassCode)
+		b.WriteByte('|')
+		b.WriteString(bh.CompanyEntryDescription)
+		b.WriteByte('|')
+		b.WriteString(bh.EffectiveEntryDate)
+		b.WriteByte('|')
+		b.WriteString(bh.ODFIIdentification)
+		b.WriteByte('|')
+	}
+	b.WriteString(entry.String())
+	return b.String()
 }
 
 // mergedFile represents a single merged file structure used in the merging and uploading process.
@@ -778,7 +796,7 @@ func (m *filesystemMerging) findInputFilepaths(mappings entryFileMapping, merged
 		for j := range merged[i].ACHFile.Batches {
 			batch := merged[i].ACHFile.Batches[j]
 
-			bh := batch.GetHeader().String()
+			bh := batch.GetHeader()
 			entries := batch.GetEntries()
 
 			for idx := range entries {

--- a/internal/pipeline/merging_mapping_test.go
+++ b/internal/pipeline/merging_mapping_test.go
@@ -393,3 +393,184 @@ func TestMerging_DistinctEntries_StillUpload(t *testing.T) {
 func serviceShard(name string) service.Shard {
 	return service.Shard{Name: name}
 }
+
+type ccdOpts struct {
+	fileID  string
+	amount  int
+	seq     int
+	addenda string // empty = no addenda
+	header  func(*ach.BatchHeader)
+}
+
+func enqueueCCD(t *testing.T, merging XferMerging, shardKey string, opts ccdOpts) {
+	t.Helper()
+
+	file := ach.NewFile()
+	file.SetHeader(staticFileHeader())
+
+	bh := mockBatchPPDHeader()
+	bh.ServiceClassCode = ach.MixedDebitsAndCredits
+	bh.StandardEntryClassCode = ach.CCD
+	bh.CompanyEntryDescription = "PAYMENT"
+	if opts.header != nil {
+		opts.header(bh)
+	}
+
+	batch := ach.NewBatchCCD(bh)
+	entry := mockPPDEntryDetail()
+	entry.Amount = opts.amount
+	entry.TransactionCode = ach.CheckingCredit
+	entry.SetTraceNumber(bh.ODFIIdentification, opts.seq)
+	if opts.addenda != "" {
+		a := ach.NewAddenda05()
+		a.PaymentRelatedInformation = opts.addenda
+		entry.AddendaRecordIndicator = 1
+		entry.AddAddenda05(a)
+	}
+	batch.AddEntry(entry)
+	require.NoError(t, batch.Create())
+	file.AddBatch(batch)
+	require.NoError(t, file.Create())
+
+	err := merging.HandleXfer(context.Background(), incoming.ACHFile{
+		FileID:   opts.fileID,
+		ShardKey: shardKey,
+		File:     file,
+	})
+	require.NoError(t, err)
+}
+
+func TestMerging_MergeEqualHeader_DifferentDiscretionaryData_MapsAll(t *testing.T) {
+	// MergeDir combines batches with BatchHeader.Equal, which ignores
+	// CompanyDiscretionaryData. Entries from the second file land under the
+	// first file's header, so a mapping key built from header.String()[:87]
+	// misses those inputs.
+	const shard = "SD-disc"
+	merging, _ := testMergingSetup(t, serviceShard(shard))
+
+	enqueueCCD(t, merging, shard, ccdOpts{fileID: "disc-a.ach", amount: 1000, seq: 1})
+	enqueueCCD(t, merging, shard, ccdOpts{
+		fileID:  "disc-b.ach",
+		amount:  2000,
+		seq:     2,
+		addenda: "INV*1001",
+		header: func(bh *ach.BatchHeader) {
+			bh.CompanyDiscretionaryData = "CODE1"
+		},
+	})
+
+	merged, err := merging.WithEachMerged(context.Background(), func(_ context.Context, idx int, _ upload.Agent, _ *ach.File) (string, error) {
+		return fmt.Sprintf("disc-out-%d.ach", idx), nil
+	})
+	require.NoError(t, err)
+	require.Len(t, merged, 1)
+	require.ElementsMatch(t, []string{"disc-a.ach", "disc-b.ach"}, merged[0].InputFilepaths)
+}
+
+func TestMerging_MergeEqualHeader_DifferentDescriptiveDate_MapsAll(t *testing.T) {
+	const shard = "SD-descdate"
+	merging, _ := testMergingSetup(t, serviceShard(shard))
+
+	enqueueCCD(t, merging, shard, ccdOpts{fileID: "date-a.ach", amount: 1111, seq: 10})
+	enqueueCCD(t, merging, shard, ccdOpts{
+		fileID:  "date-b.ach",
+		amount:  2222,
+		seq:     11,
+		addenda: "INV*1002",
+		header: func(bh *ach.BatchHeader) {
+			bh.CompanyDescriptiveDate = "Sep 01"
+		},
+	})
+
+	merged, err := merging.WithEachMerged(context.Background(), func(_ context.Context, idx int, _ upload.Agent, _ *ach.File) (string, error) {
+		return fmt.Sprintf("date-out-%d.ach", idx), nil
+	})
+	require.NoError(t, err)
+	require.Len(t, merged, 1)
+	require.ElementsMatch(t, []string{"date-a.ach", "date-b.ach"}, merged[0].InputFilepaths)
+}
+
+func TestMerging_MergeEqualHeader_CompanyNameCase_MapsAll(t *testing.T) {
+	const shard = "SD-case"
+	merging, _ := testMergingSetup(t, serviceShard(shard))
+
+	enqueueCCD(t, merging, shard, ccdOpts{fileID: "case-a.ach", amount: 3333, seq: 20})
+	enqueueCCD(t, merging, shard, ccdOpts{
+		fileID:  "case-b.ach",
+		amount:  4444,
+		seq:     21,
+		addenda: "INV*1003",
+		header: func(bh *ach.BatchHeader) {
+			bh.CompanyName = "acme corporation"
+		},
+	})
+
+	merged, err := merging.WithEachMerged(context.Background(), func(_ context.Context, idx int, _ upload.Agent, _ *ach.File) (string, error) {
+		return fmt.Sprintf("case-out-%d.ach", idx), nil
+	})
+	require.NoError(t, err)
+	require.Len(t, merged, 1)
+	require.ElementsMatch(t, []string{"case-a.ach", "case-b.ach"}, merged[0].InputFilepaths)
+}
+
+func TestMerging_MergeEqualHeader_DifferentOriginatorStatus_MapsAll(t *testing.T) {
+	const shard = "SD-origstat"
+	merging, _ := testMergingSetup(t, serviceShard(shard))
+
+	enqueueCCD(t, merging, shard, ccdOpts{
+		fileID: "orig-a.ach", amount: 5555, seq: 30,
+		header: func(bh *ach.BatchHeader) {
+			bh.OriginatorStatusCode = 1
+		},
+	})
+	enqueueCCD(t, merging, shard, ccdOpts{
+		fileID:  "orig-b.ach",
+		amount:  6666,
+		seq:     31,
+		addenda: "INV*1004",
+		header: func(bh *ach.BatchHeader) {
+			bh.OriginatorStatusCode = 2
+		},
+	})
+
+	merged, err := merging.WithEachMerged(context.Background(), func(_ context.Context, idx int, _ upload.Agent, _ *ach.File) (string, error) {
+		return fmt.Sprintf("orig-out-%d.ach", idx), nil
+	})
+	require.NoError(t, err)
+	require.Len(t, merged, 1)
+	require.ElementsMatch(t, []string{"orig-a.ach", "orig-b.ach"}, merged[0].InputFilepaths)
+}
+
+func TestMerging_CCDAddenda_MixedWithNonAddenda_MapsAll(t *testing.T) {
+	const shard = "SD-addenda-mix"
+	merging, _ := testMergingSetup(t, serviceShard(shard))
+
+	enqueueCCD(t, merging, shard, ccdOpts{fileID: "plain-1.ach", amount: 1000, seq: 1})
+	enqueueCCD(t, merging, shard, ccdOpts{fileID: "addenda-a.ach", amount: 2000, seq: 2, addenda: "INV*2001"})
+	enqueueCCD(t, merging, shard, ccdOpts{fileID: "plain-2.ach", amount: 3000, seq: 3})
+	enqueueCCD(t, merging, shard, ccdOpts{fileID: "addenda-b.ach", amount: 4000, seq: 4, addenda: "INV*2002"})
+
+	merged, err := merging.WithEachMerged(context.Background(), func(_ context.Context, idx int, _ upload.Agent, _ *ach.File) (string, error) {
+		return fmt.Sprintf("mix-out-%d.ach", idx), nil
+	})
+	require.NoError(t, err)
+	require.Len(t, merged, 1)
+	require.ElementsMatch(t, []string{"plain-1.ach", "addenda-a.ach", "plain-2.ach", "addenda-b.ach"}, merged[0].InputFilepaths)
+}
+
+func TestMakeKey_MatchesMergeEqualNotFullHeaderString(t *testing.T) {
+	entry := mockPPDEntryDetail()
+
+	a := mockBatchPPDHeader()
+	b := mockBatchPPDHeader()
+	b.CompanyDiscretionaryData = "CODE1"
+	b.CompanyDescriptiveDate = "Sep 01"
+	b.SettlementDate = "123"
+	b.OriginatorStatusCode = 2
+	b.CompanyName = "acme corporation"
+	b.BatchNumber = 99
+
+	require.True(t, a.Equal(b), "precondition: merge would combine these batches")
+	require.NotEqual(t, a.String()[:87], b.String()[:87], "precondition: full header strings differ")
+	require.Equal(t, makeKey(a, entry), makeKey(b, entry), "mapping key must follow BatchHeader.Equal, not String()[:87]")
+}

--- a/internal/pipeline/merging_mapping_test.go
+++ b/internal/pipeline/merging_mapping_test.go
@@ -225,7 +225,7 @@ func TestAccumulateMappings_DuplicateEntryIdentityQueuesBoth(t *testing.T) {
 	require.NoError(t, m.accumulateMappings(mappings, seen, "iso/first.ach"))
 	require.NoError(t, m.accumulateMappings(mappings, seen, "iso/second.ach"))
 
-	key := makeKey(batch.GetHeader().String(), entry)
+	key := makeKey(batch.GetHeader(), entry)
 	require.ElementsMatch(t, []string{"first.ach", "second.ach"}, mappings[key])
 	require.Equal(t, []string{"first.ach", "second.ach"}, crossFileDuplicateIdentityFiles(mappings))
 }
@@ -286,7 +286,7 @@ func TestFindInputFilepaths_DuplicateIdentityConsumesQueue(t *testing.T) {
 		return f
 	}
 
-	key := makeKey(mockBatchPPDHeader().String(), func() *ach.EntryDetail {
+	key := makeKey(mockBatchPPDHeader(), func() *ach.EntryDetail {
 		e := mockPPDEntryDetail()
 		e.Amount = 50
 		e.SetTraceNumber(mockBatchPPDHeader().ODFIIdentification, 9)

--- a/internal/pipeline/merging_unit_test.go
+++ b/internal/pipeline/merging_unit_test.go
@@ -66,17 +66,19 @@ func TestMakeKey_StripsBatchNumber(t *testing.T) {
 	bh2.BatchNumber = 99
 
 	entry := mockPPDEntryDetail()
-	k1 := makeKey(bh1.String(), entry)
-	k2 := makeKey(bh2.String(), entry)
+	k1 := makeKey(bh1, entry)
+	k2 := makeKey(bh2, entry)
 	require.Equal(t, k1, k2, "keys must ignore batch number so merge renumbering still matches")
 	require.NotContains(t, k1, "0000099")
 }
 
 func TestMakeKey_ShortHeader(t *testing.T) {
 	entry := mockPPDEntryDetail()
-	// Short/empty headers should not panic
-	require.NotEmpty(t, makeKey("", entry))
-	require.NotEmpty(t, makeKey("short", entry))
+	// Nil headers / entries should not panic or collide with a real key.
+	require.NotEmpty(t, makeKey(nil, entry))
+	nilKey := makeKey(nil, nil)
+	require.NotEmpty(t, nilKey)
+	require.NotEqual(t, makeKey(nil, entry), nilKey)
 }
 
 func TestMerging_HandleCancel_MissingFile(t *testing.T) {


### PR DESCRIPTION
## What

- Key `FileUploaded` input mapping with the same batch-header fields `MergeDir` uses (`BatchHeader.Equal`), instead of `BatchHeader.String()[:87]`
- Add regression tests for files whose headers `Equal()` sibling batches but differ in discretionary data, descriptive date, company-name case, or originator status

## Why

`MergeDir` copies entries under the first batch whose header `Equal()` matches. `Equal()` ignores company discretionary data, descriptive date, settlement date, originator status, and company-name case — all of which are in the 87-character NACHA header string the mapping used. After merge, those inputs no longer keyed to the uploaded file, so `FileUploaded` was skipped even though the ACH went out.

## Notes

A nil entry now maps to a non-empty sentinel. Returning `""` would collide with other mapping keys.